### PR TITLE
Add assignee into the serialized information

### DIFF
--- a/app/controllers/v1/workflow/processes_controller.rb
+++ b/app/controllers/v1/workflow/processes_controller.rb
@@ -3,6 +3,6 @@ class V1::Workflow::ProcessesController < ApiController
     # TODO: identify current user, check if process id is accessible to user
     @process = Workflow::Instance::Process.find_by!(external_identifier: params[:id])
 
-    render json: V1::Workflow::ProcessSerializer.new(@process, include: ['workflow', 'steps'])
+    render json: V1::Workflow::ProcessSerializer.new(@process, include: ['workflow', 'steps', 'assignee'])
   end
 end

--- a/app/serializers/v1/person_serializer.rb
+++ b/app/serializers/v1/person_serializer.rb
@@ -3,7 +3,7 @@
 module V1
   class PersonSerializer < ApplicationSerializer
     attributes :email, :first_name, :middle_name, :last_name, :phone, :journey_state,
-      :personal_email, :about, :primary_language, :updated_at
+      :personal_email, :about, :primary_language, :updated_at, :image_url
 
     attribute :role_list
     # has_many :roles, serializer: V1::TagSerializer

--- a/app/serializers/v1/workflow/process_serializer.rb
+++ b/app/serializers/v1/workflow/process_serializer.rb
@@ -6,8 +6,13 @@ class V1::Workflow::ProcessSerializer < ApplicationSerializer
       process.workflow
     end
 
-  has_many :steps, serializer: V1::Workflow::StepSerializer, record_type: :workflow_instance_step,
-    id_method_name: :external_identifier do |process|
+  has_many :steps, record_type: :workflow_instance_step, id_method_name: :external_identifier,
+    serializer: V1::Workflow::StepSerializer do |process|
       process.steps
     end
+
+  belongs_to :assignee, record_type: :people, id_method_name: :external_identifier,
+    serializer: V1::PersonSerializer do |process|
+    process.assignee
+  end
 end

--- a/gems/workflow/app/models/workflow/instance/process.rb
+++ b/gems/workflow/app/models/workflow/instance/process.rb
@@ -6,7 +6,7 @@ module Workflow
 
     has_many :steps, :class_name => 'Workflow::Instance::Step', foreign_key: 'workflow_instance_process_id'
     belongs_to :workflow, :class_name => 'Workflow::Instance::Workflow', foreign_key: 'workflow_instance_workflow_id'
-    belongs_to :assignee, :class_name => '::User', foreign_key: 'user_id', optional: true
+    belongs_to :assignee, :class_name => 'Person', foreign_key: 'assignee_id', optional: true
 
     acts_as_taggable_on :categories
     enum effort: { small: 0, medium: 1, large: 2 }


### PR DESCRIPTION
Processes has an assignee that needs to be part of the serializer.

@keithtom this feels a little weird because the gem has an outside dependency, an existence of a `Person` model. A way around this is a process is not responsible for knowing who it's assigned to. We create some other join model in the SSJ. let me know what you think.