### PR TITLE
Cleanup and Status related info for Process Serializer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,10 +112,10 @@ GEM
     elastic-transport (8.1.0)
       faraday (< 3)
       multi_json
-    elasticsearch (8.5.1)
+    elasticsearch (8.3.0)
       elastic-transport (~> 8)
-      elasticsearch-api (= 8.5.1)
-    elasticsearch-api (8.5.1)
+      elasticsearch-api (= 8.3.0)
+    elasticsearch-api (8.3.0)
       multi_json
     erubi (1.11.0)
     factory_bot (6.2.1)

--- a/app/controllers/v1/workflow/processes_controller.rb
+++ b/app/controllers/v1/workflow/processes_controller.rb
@@ -11,8 +11,7 @@ class V1::Workflow::ProcessesController < ApiController
     @process = Workflow::Instance::Process.find_by!(external_identifier: params[:id])
     @person = Person.find_by!(external_identifier: process_params[:assignee_id])
 
-    assigner = Workflow::Instance::Process::AssignPerson.new(@process, @person)
-    assigner.run
+    Workflow::Instance::Process::AssignPerson.run(@process, @person)
 
     render json: V1::Workflow::ProcessSerializer.new(@process, include: ['workflow', 'steps', 'assignee'])
   end

--- a/app/controllers/v1/workflow/steps_controller.rb
+++ b/app/controllers/v1/workflow/steps_controller.rb
@@ -1,8 +1,7 @@
 class V1::Workflow::StepsController < ApiController
   def create
     @process = Workflow::Instance::Process.find_by!(external_identifier: params[:process_id])
-    step_creator = Workflow::Instance::Process::AddManualStep.new(@process, step_params)
-    @step = step_creator.run
+    @step = Workflow::Instance::Process::AddManualStep.run(@process, step_params)
     render json: V1::Workflow::StepSerializer.new(@step)
   end
 
@@ -18,8 +17,7 @@ class V1::Workflow::StepsController < ApiController
     @process = Workflow::Instance::Process.find_by!(external_identifier: params[:process_id])
     @step = @process.steps.find_by!(external_identifier: params[:id])
 
-    completer = Workflow::Instance::Step::Complete.new(@step)
-    completer.run
+    Workflow::Instance::Step::Complete.run(@step)
 
     render json: V1::Workflow::StepSerializer.new(@step)
   end
@@ -29,8 +27,7 @@ class V1::Workflow::StepsController < ApiController
     @process = Workflow::Instance::Process.find_by!(external_identifier: params[:process_id])
     @step = @process.steps.find_by!(external_identifier: params[:id])
 
-    uncompleter = Workflow::Instance::Step::Uncomplete.new(@step)
-    uncompleter.run
+    Workflow::Instance::Step::Uncomplete.run(@step)
 
     render json: V1::Workflow::StepSerializer.new(@step)
   end

--- a/app/serializers/concerns/v1/statusable.rb
+++ b/app/serializers/concerns/v1/statusable.rb
@@ -1,0 +1,52 @@
+module V1::Statusable
+  extend ActiveSupport::Concern
+
+  UNSTARTED = "unstarted"
+  TO_DO = "to do"
+  IN_PROGRESS = "in progress"
+  DONE = "done"
+  UP_NEXT = "up next"
+
+  COMPLETION_STATUS = [TO_DO, IN_PROGRESS, DONE]
+  STATUS = [TO_DO, UP_NEXT, DONE]
+
+  class_methods do
+    def status(process)
+      case completion_status(process)
+      when UNSTARTED
+        return prerequisites_completed?(process) ? TO_DO : UP_NEXT
+      when IN_PROGRESS
+        return TO_DO
+      else
+        return DONE
+      end
+    end
+
+    private
+
+    def completion_status(process)
+      step_count = process.steps.count
+      completed_count = process.steps.where(completed: true).count
+
+      case completed_count
+      when 0
+        return UNSTARTED
+      when step_count
+        return DONE
+      else
+        return IN_PROGRESS
+      end
+    end
+
+    def prerequisites_completed?(process)
+      completed = true
+      process.prerequisites.each do |prerequisite|
+        if completion_status(prerequisite) != DONE
+          completed = false
+        end
+      end
+
+      return completed
+    end
+  end
+end

--- a/app/serializers/concerns/v1/statusable.rb
+++ b/app/serializers/concerns/v1/statusable.rb
@@ -22,16 +22,21 @@ module V1::Statusable
       end
     end
 
+    def completed_steps_count(process)
+      process.steps.where(completed: true).count
+    end
+
+    def total_steps_count(process)
+      step_count = process.steps.count
+    end
+
     private
 
     def completion_status(process)
-      step_count = process.steps.count
-      completed_count = process.steps.where(completed: true).count
-
-      case completed_count
+      case completed_steps_count(process)
       when 0
         return UNSTARTED
-      when step_count
+      when total_steps_count(process)
         return DONE
       else
         return IN_PROGRESS

--- a/app/serializers/v1/workflow/process_serializer.rb
+++ b/app/serializers/v1/workflow/process_serializer.rb
@@ -1,5 +1,11 @@
 class V1::Workflow::ProcessSerializer < ApplicationSerializer
-  attributes :title, :effort, :categories, :status, :position #, :assignee
+  include V1::Statusable
+
+  attributes :title, :effort, :categories, :position #, :assignee
+
+  attribute :status do |process|
+    status(process)
+  end
 
   belongs_to :workflow, record_type: :workflow_instance_workflow, id_method_name: :external_identifier,
     serializer: V1::Workflow::WorkflowSerializer do |process|

--- a/app/serializers/v1/workflow/process_serializer.rb
+++ b/app/serializers/v1/workflow/process_serializer.rb
@@ -7,6 +7,14 @@ class V1::Workflow::ProcessSerializer < ApplicationSerializer
     status(process)
   end
 
+  attribute :total_steps_count do |process|
+    total_steps_count(process)
+  end
+
+  attribute :completed_steps_count do |process|
+    completed_steps_count(process)
+  end
+
   belongs_to :workflow, record_type: :workflow_instance_workflow, id_method_name: :external_identifier,
     serializer: V1::Workflow::WorkflowSerializer do |process|
       process.workflow

--- a/docs/dev/basic_environment.md
+++ b/docs/dev/basic_environment.md
@@ -37,3 +37,9 @@ Setup your local database and schema:
 rake db:create
 rake db:migrate
 ```
+
+## Installing Elasticsearch
+1. Install directly from website, by following directions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/targz.html#install-macos). Do not use homebrew.
+2. Update the `config/elasticsearch.yml` file such that `xpack.security.enabled` is set to `false`
+3. Run `./bin/elasticsearch` from inside the directory
+4. Test the server is running correctly by running `curl -X GET "localhost:9200/?pretty"`

--- a/gems/workflow/app/models/workflow/instance/process.rb
+++ b/gems/workflow/app/models/workflow/instance/process.rb
@@ -19,10 +19,6 @@ module Workflow
     acts_as_taggable_on :categories
     enum effort: { small: 0, medium: 1, large: 2 }
 
-    TO_DO = "to do"
-    IN_PROGRESS = "in progress"
-    DONE = "done"
-
     def title
       super || self.definition.title
     end
@@ -33,20 +29,6 @@ module Workflow
 
     def effort
       super || self.definition.effort
-    end
-
-    def status
-      step_count = self.steps.count
-      completed_count = steps.where(completed: true).count
-
-      case completed_count
-      when 0
-        return TO_DO
-      when step_count
-        return DONE
-      else
-        return IN_PROGRESS
-      end
     end
 
     def workflow_url

--- a/gems/workflow/app/models/workflow/instance/step.rb
+++ b/gems/workflow/app/models/workflow/instance/step.rb
@@ -2,7 +2,7 @@ module Workflow
   class Instance::Step < ApplicationRecord
     include ApplicationRecord::ExternalIdentifier
 
-    belongs_to :definition, class_name: 'Workflow::Definition::Step'
+    belongs_to :definition, class_name: 'Workflow::Definition::Step', optional: true
     belongs_to :process, class_name: 'Workflow::Instance::Process'
 
 

--- a/gems/workflow/app/services/workflow/instance/process/add_manual_step.rb
+++ b/gems/workflow/app/services/workflow/instance/process/add_manual_step.rb
@@ -1,6 +1,6 @@
 module Workflow
   class Instance::Process
-    class AddManualStep
+    class AddManualStep < Workflow::Service
       def initialize(process, step_params)
         @process = process
         @step_params = step_params
@@ -11,7 +11,6 @@ module Workflow
         last_step_position = last_step.nil? ? 0 : last_step.position + 100
         @step_params[:position] = last_step_position + 100
         step = @process.steps.create!(@step_params)
-
         return step
       end
     end

--- a/gems/workflow/app/services/workflow/instance/process/assign_person.rb
+++ b/gems/workflow/app/services/workflow/instance/process/assign_person.rb
@@ -1,6 +1,6 @@
 module Workflow
   class Instance::Process
-    class AssignPerson
+    class AssignPerson < Workflow::Service
       def initialize(process, person)
         @process = process
         @person = person

--- a/gems/workflow/app/services/workflow/instance/step/complete.rb
+++ b/gems/workflow/app/services/workflow/instance/step/complete.rb
@@ -1,6 +1,6 @@
 module Workflow
   class Instance::Step
-    class Complete
+    class Complete < Workflow::Service
       # track startability of new steps as a metric, e.g. what did we unlock and as of when
       # that way we can see what's waiting in someone's court.
       # particularly for non-workers

--- a/gems/workflow/app/services/workflow/instance/step/uncomplete.rb
+++ b/gems/workflow/app/services/workflow/instance/step/uncomplete.rb
@@ -1,6 +1,6 @@
 module Workflow
   class Instance::Step
-    class Uncomplete
+    class Uncomplete < Workflow::Service
       def initialize(step)
         @step = step
       end

--- a/gems/workflow/app/services/workflow/service.rb
+++ b/gems/workflow/app/services/workflow/service.rb
@@ -6,5 +6,11 @@ module Workflow
 
     # given a specific step, query what dependencies must be met
     # query 3rd party work (steps that are avaialble and waiting on not you)
+    def self.run(*args)
+      new(*args).run
+    end
+
+    class Error < StandardError
+    end
   end
 end

--- a/spec/requests/v1/workflow/processes_spec.rb
+++ b/spec/requests/v1/workflow/processes_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe "V1::Workflow::Processes", type: :request do
       get "/v1/workflow/processes/#{process.external_identifier}", headers: headers
       expect(response).to have_http_status(:success)
       expect(json_response["data"]).to have_type(:process).and have_attribute(:status)
+      expect(json_response["data"]).to have_type(:process).and have_attribute(:totalStepsCount)
+      expect(json_response["data"]).to have_type(:process).and have_attribute(:completedStepsCount)
     end
   end
 end

--- a/spec/requests/v1/workflow/processes_spec.rb
+++ b/spec/requests/v1/workflow/processes_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe "V1::Workflow::Processes", type: :request do
   let(:headers) { {'ACCEPT' => 'application/json'} }
   let(:person) { create(:person) }
-  let (:workflow_definition) { Workflow::Definition::Workflow.create!(version: "1.0", name: "Visioning", description: "Imagine the school of your dreams") }
-  let (:workflow) { Workflow::Instance::Workflow.create!(definition: workflow_definition) }
+  let(:workflow_definition) { Workflow::Definition::Workflow.create!(version: "1.0", name: "Visioning", description: "Imagine the school of your dreams") }
+  let(:workflow) { Workflow::Instance::Workflow.create!(definition: workflow_definition) }
   let(:process_definition) { Workflow::Definition::Process.create!(title: "file taxes", description: "pay taxes to the IRS", effort: 2) }
   let(:process) { Workflow::Instance::Process.create!(definition: process_definition, workflow: workflow) }
 
@@ -14,6 +14,14 @@ RSpec.describe "V1::Workflow::Processes", type: :request do
         params: { process: { assignee_id: person.external_identifier } }
       expect(response).to have_http_status(:success)
       expect(process.reload.assignee).to eq(person)
+    end
+  end
+
+  describe "GET /v1/processes/6823-2341" do
+    it "succeeds" do
+      get "/v1/workflow/processes/#{process.external_identifier}", headers: headers
+      expect(response).to have_http_status(:success)
+      expect(json_response["data"]).to have_type(:process).and have_attribute(:status)
     end
   end
 end

--- a/spec/serializers/concerns/v1/statusable.rb
+++ b/spec/serializers/concerns/v1/statusable.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe V1::Statusable, type: :concern do
+  let(:person) { create(:person) }
+  let (:workflow_definition) { Workflow::Definition::Workflow.create!(version: "1.0", name: "Visioning", description: "Imagine the school of your dreams") }
+  let (:workflow) { Workflow::Instance::Workflow.create!(definition: workflow_definition) }
+  let(:process_definition) { Workflow::Definition::Process.create!(title: "file taxes", description: "pay taxes to the IRS", effort: 2) }
+  let(:process) { Workflow::Instance::Process.create!(definition: process_definition, workflow: workflow) }
+  before do
+  end
+
+  context "steps unstarted" do
+    context "all prerequisites met" do
+      it "has todo status" do
+        
+      end
+    end
+
+    context "prerequisites unmet" do
+      it "has up next status do" do
+      end
+   end
+  end
+end

--- a/spec/serializers/concerns/v1/statusable_spec.rb
+++ b/spec/serializers/concerns/v1/statusable_spec.rb
@@ -1,0 +1,145 @@
+require 'rails_helper'
+
+class StatusableFakeSerializer
+  include V1::Statusable
+end
+
+RSpec.describe V1::Statusable, type: :concern do
+  let(:workflow_definition) { Workflow::Definition::Workflow.create!(version: "1.0", name: "Visioning", description: "Imagine the school of your dreams") }
+  let(:workflow) { Workflow::Instance::Workflow.create!(definition: workflow_definition) }
+  let(:process_definition) { Workflow::Definition::Process.create!(title: "file taxes", description: "pay taxes to the IRS", effort: 2) }
+  let(:process) { Workflow::Instance::Process.create!(definition: process_definition, workflow: workflow) }
+
+  before do
+    3.times do
+      process.steps.create!
+    end
+  end
+
+  context "steps unstarted" do
+    let(:prerequisite_definition) { Workflow::Definition::Process.create!(title: "prepare taxes", description: "gather tax worksheets", effort: 2) }
+    let(:prerequisite) { Workflow::Instance::Process.create!(definition: prerequisite_definition, workflow: workflow) }
+    let(:dependency_definition) { Workflow::Definition::Dependency.create!(workflow: workflow_definition, workable: process_definition, prerequisite_workable: prerequisite_definition) }
+    let!(:dependency) { Workflow::Instance::Dependency.create!(workflow: workflow, workable: process, prerequisite_workable: prerequisite, definition: dependency_definition) }
+
+    before do
+      prerequisite.steps.create!
+    end
+
+    context "prerequisites unmet" do
+      it "has 'up next' status" do
+        process.steps.each do |step|
+          expect(step.completed).to be_falsey
+        end
+
+        expect(process.prerequisites.count).to_not eq(0)
+        process.prerequisites.each do |prereq|
+          expect(StatusableFakeSerializer.status(prereq)).to eq(V1::Statusable::TO_DO)
+        end
+
+        expect(StatusableFakeSerializer.status(process)).to eq(V1::Statusable::UP_NEXT)
+      end
+    end
+
+    context "all prerequisites met" do
+      before do
+        process.prerequisites.each do |prereq|
+          prereq.steps.each do |step|
+            step.completed = true
+            step.completed_at = DateTime.now
+            step.save!
+          end
+        end
+      end
+
+      it "has 'to do' status" do
+        expect(StatusableFakeSerializer.status(process)).to eq(V1::Statusable::TO_DO)
+      end
+    end
+  end
+
+  context "1 of 3 steps completed" do
+    let(:prerequisite_definition) { Workflow::Definition::Process.create!(title: "prepare taxes", description: "gather tax worksheets", effort: 2) }
+    let(:prerequisite) { Workflow::Instance::Process.create!(definition: prerequisite_definition, workflow: workflow) }
+    let(:dependency_definition) { Workflow::Definition::Dependency.create!(workflow: workflow_definition, workable: process_definition, prerequisite_workable: prerequisite_definition) }
+    let!(:dependency) { Workflow::Instance::Dependency.create!(workflow: workflow, workable: process, prerequisite_workable: prerequisite, definition: dependency_definition) }
+
+    before do
+      prerequisite.steps.create!
+
+      step = process.steps.first
+      step.completed = true
+      step.save!
+    end
+
+    context "prerequisites unmet" do
+      it "has 'to do' status" do
+        expect(process.prerequisites.count).to_not eq(0)
+        process.prerequisites.each do |prereq|
+          expect(StatusableFakeSerializer.status(prereq)).to eq(V1::Statusable::TO_DO)
+        end
+
+        expect(StatusableFakeSerializer.status(process)).to eq(V1::Statusable::TO_DO)
+      end
+    end
+
+    context "all prerequisites met" do
+      before do
+        process.prerequisites.each do |prereq|
+          prereq.steps.each do |step|
+            step.completed = true
+            step.completed_at = DateTime.now
+            step.save!
+          end
+        end
+      end
+
+      it "has 'to do' status" do
+        expect(StatusableFakeSerializer.status(process)).to eq(V1::Statusable::TO_DO)
+      end
+    end
+  end
+
+  context "3 of 3 steps completed" do
+    let(:prerequisite_definition) { Workflow::Definition::Process.create!(title: "prepare taxes", description: "gather tax worksheets", effort: 2) }
+    let(:prerequisite) { Workflow::Instance::Process.create!(definition: prerequisite_definition, workflow: workflow) }
+    let(:dependency_definition) { Workflow::Definition::Dependency.create!(workflow: workflow_definition, workable: process_definition, prerequisite_workable: prerequisite_definition) }
+    let!(:dependency) { Workflow::Instance::Dependency.create!(workflow: workflow, workable: process, prerequisite_workable: prerequisite, definition: dependency_definition) }
+
+    before do
+      prerequisite.steps.create!
+
+      process.steps.each do |step|
+        step.completed = true
+        step.save!
+      end
+    end
+
+    context "prerequisites unmet" do
+      it "has 'done' status" do
+        expect(process.prerequisites.count).to_not eq(0)
+        process.prerequisites.each do |prereq|
+          expect(StatusableFakeSerializer.status(prereq)).to eq(V1::Statusable::TO_DO)
+        end
+
+        expect(StatusableFakeSerializer.status(process)).to eq(V1::Statusable::DONE)
+      end
+    end
+
+    context "all prerequisites met" do
+      before do
+        process.prerequisites.each do |prereq|
+          prereq.steps.each do |step|
+            step.completed = true
+            step.completed_at = DateTime.now
+            step.save!
+          end
+        end
+      end
+
+      it "has 'done' status" do
+        expect(StatusableFakeSerializer.status(process)).to eq(V1::Statusable::DONE)
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. Clean up service workers to just use `.run` like a singleton
2. Pull all status related code into a concern
3. Update README for installing elasticsearch locally
4. Add total and completed steps to Process serializer