### PR TITLE
Tweak API for Step Member Actions

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,11 +60,12 @@ Rails.application.routes.draw do
           put :assign
         end
 
-        resources :steps, only: [:create, :show] do
-          member do
-            put :complete
-            put :uncomplete
-          end
+        resources :steps, only: [:create, :show]
+      end
+      resources :steps, only: [] do
+        member do
+          put :complete
+          put :uncomplete
         end
       end
     end


### PR DESCRIPTION
moved API for steps member actions to not be scoped to process ID so it is easier to use API.