### PR TITLE
Expose auth headers to requests coming from other port/url

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3001 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -12,6 +12,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource "*",
       headers: :any,
       # credentials: true,
+      expose: ["Authorization"],
       methods: [:get, :post, :put, :patch, :delete, :options, :head]
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,7 @@ worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch('PORT', 3000)
+port ENV.fetch('PORT', 3001)
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
When testing with Taylor, we could log in successfully, but didn't get an auth header. Need this change to get it.