### PR TITLE
Setting jwt in httpOnly cookie 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'puma', '~> 5.0'
 #authentication
 gem 'devise'
 gem 'devise-jwt'
+gem 'devise-jwt-cookie', github: 'absolute-boi/devise-jwt-cookie'
  
 # Use Puma as the app server
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'puma', '~> 5.0'
 #authentication
 gem 'devise'
 gem 'devise-jwt'
-gem 'devise-jwt-cookie', github: 'absolute-boi/devise-jwt-cookie'
+gem 'devise-jwt-cookie', github: 'styliii/devise-jwt-cookie'
  
 # Use Puma as the app server
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/absolute-boi/devise-jwt-cookie.git
+  revision: fe61416f10cdf196d19a64dd72ee60c5d54d7c0d
+  specs:
+    devise-jwt-cookie (0.6.0)
+      devise-jwt (~> 0.10.0)
+      dry-auto_inject
+      dry-configurable
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -350,6 +359,7 @@ DEPENDENCIES
   database_cleaner-active_record
   devise
   devise-jwt
+  devise-jwt-cookie!
   dotenv-rails
   elasticsearch (~> 8.x)
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/absolute-boi/devise-jwt-cookie.git
+  remote: https://github.com/styliii/devise-jwt-cookie.git
   revision: fe61416f10cdf196d19a64dd72ee60c5d54d7c0d
   specs:
     devise-jwt-cookie (0.6.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,8 @@ class User < ApplicationRecord
   include Devise::JWT::RevocationStrategies::JTIMatcher
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable, :recoverable, 
-  :validatable, :jwt_authenticatable, jwt_revocation_strategy: self
+  devise :database_authenticatable, :registerable, :recoverable,
+  :validatable, :jwt_authenticatable, :jwt_cookie_authenticatable, jwt_revocation_strategy: self
 
   belongs_to :person, optional: true
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,12 +7,11 @@
 # Access-Control-Allow-Origin
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    # origins "localhost:3000", /\Ahttps:\/\/.+\.vercel\.app/\z, "https://platform.wildflowerschools.org", "https://journey.wildflowerschools.org", "https://staging-journey.wildflowerschools.org"
-    origins '*'
+    origins "localhost:3000", "localhost:3001", "https://platform.wildflowerschools.org", "https://journey.wildflowerschools.org", "https://staging-journey.wildflowerschools.org", /\Ahttps:\/\/.+\.vercel\.app\z/
+    # origins "localhost:3000", "localhost:3001"
     resource "*",
       headers: :any,
-      # credentials: true,
-      expose: ["Authorization"],
+      credentials: true,
       methods: [:get, :post, :put, :patch, :delete, :options, :head]
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -319,4 +319,8 @@ Devise.setup do |config|
     ]
     jwt.expiration_time = 24.hours.to_i
   end
+
+  config.jwt_cookie do |jwt_cookie|
+    jwt_cookie.name = 'jwt'
+  end
 end


### PR DESCRIPTION
I don't like having so many dependencies, but had to use another gem, which isn't well maintained. It's not a lot of code, but would appreciate if you took a look at it @keithtom.

What this does is the server sends JWT in a httpOnly cookie in the response. Then, subsequent requests from the client where `credentials` are included, the cookie is sent back to browser and requests are authorized.

Have tested this locally with the frontend, specifically logging in and logging out.