### PR TITLE
Need person in Process Serializer

### DIFF
--- a/app/controllers/v1/workflow/processes_controller.rb
+++ b/app/controllers/v1/workflow/processes_controller.rb
@@ -27,4 +27,11 @@ class V1::Workflow::ProcessesController < ApiController
 
     render json: V1::Workflow::ProcessSerializer.new(@process, include: ['workflow', 'steps'])
   end
+
+  private
+
+  def process_options
+    options = {}
+    options[:include] = ['workflow', 'steps', 'person']
+  end
 end


### PR DESCRIPTION
Because process serializer includes the tasks and the tasks need assignee data, need to include person to ProcessSerializer.