### PR TITLE
Surface assignee info in nested serializers

### DIFF
--- a/app/controllers/v1/workflow/processes_controller.rb
+++ b/app/controllers/v1/workflow/processes_controller.rb
@@ -19,6 +19,9 @@ class V1::Workflow::ProcessesController < ApiController
 
     options = {include: ['workflow', 'steps']}
     if params[:assigned_to_me]
+      processes = processes.select do |process|
+        process.steps.where(assignee_id: current_user.person_id).count > 0
+      end
       options[:params] = { assignee_id: current_user.person_id }
     end
 

--- a/app/controllers/v1/workflow/processes_controller.rb
+++ b/app/controllers/v1/workflow/processes_controller.rb
@@ -18,9 +18,10 @@ class V1::Workflow::ProcessesController < ApiController
     end
 
     options = {include: ['workflow', 'steps']}
-    if params[:assigned_to_me]
+
+    if params[:self_assigned]
       processes = processes.select do |process|
-        process.steps.where(assignee_id: current_user.person_id).count > 0
+        process.steps.where(assignee_id: current_user.person_id, completed: false).count > 0
       end
       options[:params] = { assignee_id: current_user.person_id }
     end

--- a/app/controllers/v1/workflow/processes_controller.rb
+++ b/app/controllers/v1/workflow/processes_controller.rb
@@ -17,8 +17,12 @@ class V1::Workflow::ProcessesController < ApiController
       processes = workflow.processes.eager_load(:categories, steps: [:definition, :documents], definition: [:categories, steps: [:documents]]).by_position
     end
 
+    options = {include: ['workflow', 'steps']}
+    if params[:assigned_to_me]
+      options[:params] = { assignee_id: current_user.person_id }
+    end
 
-    render json: V1::Workflow::ProcessSerializer.new(processes, include: ['workflow', 'steps'])
+    render json: V1::Workflow::ProcessSerializer.new(processes, options)
   end
 
   def show

--- a/app/controllers/v1/workflow/processes_controller.rb
+++ b/app/controllers/v1/workflow/processes_controller.rb
@@ -32,6 +32,6 @@ class V1::Workflow::ProcessesController < ApiController
 
   def process_options
     options = {}
-    options[:include] = ['workflow', 'steps', 'person']
+    options[:include] = ['workflow', 'steps']
   end
 end

--- a/app/serializers/v1/workflow/process_serializer.rb
+++ b/app/serializers/v1/workflow/process_serializer.rb
@@ -18,7 +18,11 @@ class V1::Workflow::ProcessSerializer < ApplicationSerializer
     end
 
   has_many :steps, record_type: :workflow_instance_step, id_method_name: :external_identifier,
-    serializer: V1::Workflow::StepSerializer do |process|
-      process.steps
+    serializer: V1::Workflow::StepSerializer do |process, params|
+      if params[:assignee_id]
+        process.steps.where(assignee_id: params[:assignee_id])
+      else
+        process.steps
+      end
     end
 end

--- a/app/serializers/v1/workflow/step_serializer.rb
+++ b/app/serializers/v1/workflow/step_serializer.rb
@@ -26,4 +26,11 @@ class V1::Workflow::StepSerializer < ApplicationSerializer
       step.definition.decision_options.map {|decision_option| V1::Workflow::DecisionOptionSerializer.new(decision_option).to_json }
     end
   end
+
+  # bit of a hack so we can have assignee information when the step serializer is nested in the process serializer
+  attribute :assignee_info do |step|
+    if assignee = step.assignee
+      { id: assignee.id, image_url: assignee.image_url }
+    end
+  end
 end

--- a/app/serializers/v1/workflow/step_serializer.rb
+++ b/app/serializers/v1/workflow/step_serializer.rb
@@ -30,7 +30,7 @@ class V1::Workflow::StepSerializer < ApplicationSerializer
   # bit of a hack so we can have assignee information when the step serializer is nested in the process serializer
   attribute :assignee_info do |step|
     if assignee = step.assignee
-      { id: assignee.id, image_url: assignee.image_url }
+      { id: assignee.external_identifier, imageUrl: assignee.image_url }
     end
   end
 end

--- a/db/migrate/20230130185846_set_default_completed_to_false.rb
+++ b/db/migrate/20230130185846_set_default_completed_to_false.rb
@@ -1,0 +1,23 @@
+class SetDefaultCompletedToFalse < ActiveRecord::Migration[7.0]
+  def up
+    change_column :workflow_instance_steps, :completed, :bool, default: false
+
+    Workflow::Instance::Step.all.each do |step|
+      if step.completed.nil?
+        step.completed = false
+        step.save
+      end
+    end
+  end
+
+  def down
+    Workflow::Instance::Step.all.each do |step|
+      if !step.completed
+        step.completed = nil
+        step.save
+      end
+    end
+
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_18_141003) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_30_185846) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -412,7 +412,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_18_141003) do
     t.bigint "definition_id"
     t.string "title"
     t.string "kind"
-    t.boolean "completed"
+    t.boolean "completed", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"

--- a/spec/requests/v1/workflow/processes_spec.rb
+++ b/spec/requests/v1/workflow/processes_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "V1::Workflow::Processes", type: :request do
     let!(:unassigned_step) { create(:workflow_instance_step_manual, process_id: process.id) }
 
     it "succeeds" do
-      get "/v1/workflow/workflows/#{workflow.external_identifier}/processes?assigned_to_me=true", headers: headers
+      get "/v1/workflow/workflows/#{workflow.external_identifier}/processes?self_assigned=true", headers: headers
       expect(response).to have_http_status(:success)
       expect(json_response["data"][0]).to have_type(:process).and have_attribute(:status)
       expect(json_response["data"][0]).to have_type(:process).and have_attribute(:stepsCount)

--- a/spec/requests/v1/workflow/processes_spec.rb
+++ b/spec/requests/v1/workflow/processes_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe "V1::Workflow::Processes", type: :request do
   let(:workflow_definition) { Workflow::Definition::Workflow.create!(version: "1.0", name: "Visioning", description: "Imagine the school of your dreams") }
   let(:workflow) { Workflow::Instance::Workflow.create!(definition: workflow_definition) }
   let(:process_definition) { Workflow::Definition::Process.create!(title: "file taxes", description: "pay taxes to the IRS", effort: 2) }
-  let(:process) { Workflow::Instance::Process.create!(definition: process_definition, workflow: workflow) }
-  let(:user) { create(:user) }
+  let!(:process) { Workflow::Instance::Process.create!(definition: process_definition, workflow: workflow) }
+  let(:user) { create(:user, person_id: person.id) }
+  let!(:assigned_step) { create(:workflow_instance_step_manual, process_id: process.id, assignee_id: user.person_id) }
 
   before do
     sign_in(user)
@@ -20,6 +21,22 @@ RSpec.describe "V1::Workflow::Processes", type: :request do
       expect(json_response["data"]).to have_type(:process).and have_attribute(:status)
       expect(json_response["data"]).to have_type(:process).and have_attribute(:stepsCount)
       expect(json_response["data"]).to have_type(:process).and have_attribute(:completedStepsCount)
+    end
+  end
+
+  describe "GET /v1/workflow/workflows/6823-2341/processes with steps only assigned to current user" do
+    let!(:unassigned_step) { create(:workflow_instance_step_manual, process_id: process.id) }
+
+    it "succeeds" do
+      get "/v1/workflow/workflows/#{workflow.external_identifier}/processes?assigned_to_me=true", headers: headers
+      expect(response).to have_http_status(:success)
+      expect(json_response["data"][0]).to have_type(:process).and have_attribute(:status)
+      expect(json_response["data"][0]).to have_type(:process).and have_attribute(:stepsCount)
+      expect(json_response["data"][0]).to have_type(:process).and have_attribute(:completedStepsCount)
+      steps = json_response["data"][0]["relationships"]["steps"]["data"]
+      expect(steps.length).to eq(1)
+      expect(steps[0]["id"]).to_not eq(unassigned_step.external_identifier)
+      expect(steps[0]["id"]).to eq(assigned_step.external_identifier)
     end
   end
 end

--- a/spec/serializers/v1/workflow/step_serializer_spec.rb
+++ b/spec/serializers/v1/workflow/step_serializer_spec.rb
@@ -2,7 +2,8 @@
 require 'rails_helper'
 
 describe V1::Workflow::StepSerializer do
-  let(:step) { build(:workflow_instance_step) }
+  let(:assignee) { create(:person) }
+  let(:step) { build(:workflow_instance_step, assignee_id: assignee.id) }
 
   subject { described_class.new(step).as_json }
 
@@ -13,8 +14,8 @@ describe V1::Workflow::StepSerializer do
   end
 
   it "should serialize properly" do
-    puts json_document.inspect
     expect(json_document['data']).to have_relationships(:process, :documents)
     expect(json_document['data']).to have_jsonapi_attributes(:completed, :completedAt, :decisionOptions, :kind, :position, :title)
+    expect(json_document['data']). to have_jsonapi_attributes(:assigneeInfo)
   end
 end


### PR DESCRIPTION
Bit of a hack, but our json serializer doesn't show relationship object's attributes if it's nested 2 levels deep.

New behavior:
1. `StepSerializer` has an `assigneeInfo` attribute that just includes `external_identifier` and `image_url`
2. Piggyback off of the `index` action of the `ProcessesController` such that it only shows processes with tasks assigned to current user for [this card](https://trello.com/c/LSXrfQ34/126-build-an-api-endpoint-which-surfaces-assigned-tasks-by-milestone-to-be-used-on-the-ssj-dashboard)
