### PR TITLE
Filter out completed tasks 

### DIFF
--- a/app/serializers/v1/workflow/process_serializer.rb
+++ b/app/serializers/v1/workflow/process_serializer.rb
@@ -12,6 +12,10 @@ class V1::Workflow::ProcessSerializer < ApplicationSerializer
     get_categories(process)
   end
 
+  attribute :steps_assigned_count do |process|
+    process.steps.where.not(assignee_id: nil).count
+  end
+
   belongs_to :workflow, record_type: :workflow_instance_workflow, id_method_name: :external_identifier,
     serializer: V1::Workflow::WorkflowSerializer do |process|
       process.workflow

--- a/app/serializers/v1/workflow/process_serializer.rb
+++ b/app/serializers/v1/workflow/process_serializer.rb
@@ -20,7 +20,7 @@ class V1::Workflow::ProcessSerializer < ApplicationSerializer
   has_many :steps, record_type: :workflow_instance_step, id_method_name: :external_identifier,
     serializer: V1::Workflow::StepSerializer do |process, params|
       if params[:assignee_id]
-        process.steps.where(assignee_id: params[:assignee_id])
+        process.steps.where(assignee_id: params[:assignee_id], completed: false)
       else
         process.steps
       end


### PR DESCRIPTION
1. Filter out completed tasks in the self assigned endpoint
2. adds `steps_assigned_count` to process serializer