### PR TITLE
Import min/max worktime

### DIFF
--- a/app/models/SSJ/phase.rb
+++ b/app/models/SSJ/phase.rb
@@ -1,0 +1,19 @@
+module SSJ
+  # helper class to hold phase logic
+  class Phase
+    PHASES = ["visioning", "planning", "startup"]
+
+    def self.next(phase)
+      case phase
+      when "visioning"
+        "planning"
+      when "planning"
+        "startup"
+      when "startup"
+        nil
+      else
+        raise "not a valid phase"
+      end
+    end
+  end
+end

--- a/app/models/workflow/definition/process.rb
+++ b/app/models/workflow/definition/process.rb
@@ -1,7 +1,6 @@
 module Workflow
   class Definition::Process < ApplicationRecord
     DEFAULT_INCREMENT = 100
-    PHASES = ["visioning", "planning", "startup"]
 
     has_many :instances, class_name: 'Workflow::Instance::Process', foreign_key: 'definition_id'
 

--- a/app/models/workflow/definition/workflow.rb
+++ b/app/models/workflow/definition/workflow.rb
@@ -1,7 +1,5 @@
 module Workflow
   class Definition::Workflow < ApplicationRecord
-    PHASES = ["visioning", "planning", "startup"]
-
     has_many :selected_processes
     has_many :processes, through: :selected_processes # these are the nodes
 

--- a/app/serializers/v1/workflow/process_serializer.rb
+++ b/app/serializers/v1/workflow/process_serializer.rb
@@ -12,8 +12,8 @@ class V1::Workflow::ProcessSerializer < ApplicationSerializer
     get_categories(process)
   end
 
-  attribute :phase_list do |process|
-    process.definition.phase_list
+  attribute :phase do |process|
+    process.definition.phase_list.first
   end
 
 

--- a/app/serializers/v1/workflow/process_serializer.rb
+++ b/app/serializers/v1/workflow/process_serializer.rb
@@ -2,7 +2,7 @@ class V1::Workflow::ProcessSerializer < ApplicationSerializer
   include V1::Statusable
   include V1::Categorizable
 
-  attributes :title, :effort, :position, :steps_count, :completed_steps_count, :description
+  attributes :title, :effort, :position, :steps_count, :completed_steps_count, :description, :phase
 
   attribute :status do |process|
     process_status(process)

--- a/app/serializers/v1/workflow/process_serializer.rb
+++ b/app/serializers/v1/workflow/process_serializer.rb
@@ -2,7 +2,7 @@ class V1::Workflow::ProcessSerializer < ApplicationSerializer
   include V1::Statusable
   include V1::Categorizable
 
-  attributes :title, :effort, :position, :steps_count, :completed_steps_count, :description, :phase
+  attributes :title, :effort, :position, :steps_count, :completed_steps_count, :description
 
   attribute :status do |process|
     process_status(process)
@@ -11,6 +11,11 @@ class V1::Workflow::ProcessSerializer < ApplicationSerializer
   attribute :categories do |process|
     get_categories(process)
   end
+
+  attribute :phase_list do |process|
+    process.definition.phase_list
+  end
+
 
   attribute :steps_assigned_count do |process|
     process.steps.where.not(assignee_id: nil).count

--- a/app/serializers/v1/workflow/step_serializer.rb
+++ b/app/serializers/v1/workflow/step_serializer.rb
@@ -1,5 +1,5 @@
 class V1::Workflow::StepSerializer < ApplicationSerializer
-  attributes :title, :completed, :kind, :position, :completed_at, :description
+  attributes :title, :completed, :kind, :position, :completed_at, :description, :min_worktime, :max_worktime
 
   belongs_to :process, serializer: V1::Workflow::ProcessSerializer, record_type: :workflow_instance_process,
     id_method_name: :external_identifier do |step|

--- a/app/serializers/v1/workflow/step_serializer.rb
+++ b/app/serializers/v1/workflow/step_serializer.rb
@@ -1,5 +1,5 @@
 class V1::Workflow::StepSerializer < ApplicationSerializer
-  attributes :title, :completed, :kind, :position, :completed_at, :description, :min_worktime, :max_worktime
+  attributes :title, :completed, :kind, :position, :completed_at, :description
 
   belongs_to :process, serializer: V1::Workflow::ProcessSerializer, record_type: :workflow_instance_process,
     id_method_name: :external_identifier do |step|
@@ -25,6 +25,14 @@ class V1::Workflow::StepSerializer < ApplicationSerializer
     unless step.definition.nil? || step.kind != Workflow::Definition::Step::DECISION
       step.definition.decision_options.map {|decision_option| V1::Workflow::DecisionOptionSerializer.new(decision_option).to_json }
     end
+  end
+
+  attribute :min_worktime do |step|
+    step.definition&.min_worktime
+  end
+
+  attribute :max_worktime do |step|
+    step.definition&.max_worktime
   end
 
   # bit of a hack so we can have assignee information when the step serializer is nested in the process serializer

--- a/db/migrate/20230213195704_add_process_start_considering.rb
+++ b/db/migrate/20230213195704_add_process_start_considering.rb
@@ -1,0 +1,5 @@
+class AddProcessStartConsidering < ActiveRecord::Migration[7.0]
+  def change
+    add_column :workflow_definition_processes, :start_considering, :boolean, default: false
+  end
+end

--- a/db/migrate/20230213233618_add_process_min_max_duration.rb
+++ b/db/migrate/20230213233618_add_process_min_max_duration.rb
@@ -1,8 +1,8 @@
 class AddProcessMinMaxDuration < ActiveRecord::Migration[7.0]
   def change
-    add_column :workflow_definition_processes, :min_worktime, :integer, default: 0
-    add_column :workflow_definition_processes, :max_worktime, :integer, default: 0
-    remove_column :workflow_definition_processes, :effort
-    remove_column :workflow_instance_processes, :effort
+    add_column :workflow_definition_steps, :min_worktime, :integer, default: 0
+    add_column :workflow_definition_steps, :max_worktime, :integer, default: 0
+    remove_column :workflow_definition_processes, :effort, :integer
+    remove_column :workflow_instance_processes, :effort, :integer
   end
 end

--- a/db/migrate/20230213233618_add_process_min_max_duration.rb
+++ b/db/migrate/20230213233618_add_process_min_max_duration.rb
@@ -1,0 +1,8 @@
+class AddProcessMinMaxDuration < ActiveRecord::Migration[7.0]
+  def change
+    add_column :workflow_definition_processes, :min_worktime, :integer, default: 0
+    add_column :workflow_definition_processes, :max_worktime, :integer, default: 0
+    remove_column :workflow_definition_processes, :effort
+    remove_column :workflow_instance_processes, :effort
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_07_161428) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_13_195704) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -316,6 +316,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_161428) do
     t.datetime "updated_at", null: false
     t.integer "effort"
     t.integer "position"
+    t.boolean "start_considering", default: false
   end
 
   create_table "workflow_definition_selected_processes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -316,8 +316,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_13_233618) do
     t.datetime "updated_at", null: false
     t.integer "position"
     t.boolean "start_considering", default: false
-    t.integer "min_worktime", default: 0
-    t.integer "max_worktime", default: 0
   end
 
   create_table "workflow_definition_selected_processes", force: :cascade do |t|
@@ -337,6 +335,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_13_233618) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
+    t.integer "min_worktime", default: 0
+    t.integer "max_worktime", default: 0
     t.index ["process_id"], name: "index_workflow_definition_steps_on_process_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_13_195704) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_13_233618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -314,9 +314,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_13_195704) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "effort"
     t.integer "position"
     t.boolean "start_considering", default: false
+    t.integer "min_worktime", default: 0
+    t.integer "max_worktime", default: 0
   end
 
   create_table "workflow_definition_selected_processes", force: :cascade do |t|
@@ -367,7 +368,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_13_195704) do
     t.bigint "workflow_id"
     t.string "title"
     t.text "description"
-    t.integer "effort"
     t.datetime "started_at", precision: nil
     t.datetime "completed_at", precision: nil
     t.datetime "created_at", null: false

--- a/lib/ssj/workflow/import.rb
+++ b/lib/ssj/workflow/import.rb
@@ -49,13 +49,10 @@ module SSJ
             puts "creating #{process_title}"
             process_description = row[15]&.strip
             process_start_considering = row[5]&.strip.present?
-            process_min_worktime = convert_to_minutes(row[19]&.strip, row[21]&.strip)
-            process_max_worktime = convert_to_minutes(row[20]&.strip, row[21]&.strip)
-
             process_category = row[7]&.strip
             process_position += ::Workflow::Definition::Process::DEFAULT_INCREMENT
 
-            process_obj = ::Workflow::Definition::Process.create! version: default_version, title: process_title, description: process_description, min_worktime: process_min_worktime, max_worktime: process_max_worktime, position: process_position, category_list: process_category, start_considering: process_start_considering
+            process_obj = ::Workflow::Definition::Process.create! version: default_version, title: process_title, description: process_description, position: process_position, category_list: process_category, start_considering: process_start_considering
 
             step_position = 0
           elsif process_title.blank? && step_title.present?
@@ -64,7 +61,9 @@ module SSJ
             step_type = row[16]&.strip
             # step_content = row[18]&.strip
             step_position += ::Workflow::Definition::Step::DEFAULT_INCREMENT
-            step = process_obj.steps.create!(title: step_title, description: step_description, kind: step_type, position: step_position)
+            step_min_worktime = convert_to_minutes(row[19]&.strip, row[21]&.strip)
+            step_max_worktime = convert_to_minutes(row[20]&.strip, row[21]&.strip)
+            step = process_obj.steps.create!(title: step_title, description: step_description, kind: step_type, position: step_position, min_worktime: step_min_worktime, max_worktime: step_max_worktime)
 
             step_document_titles = row[23]&.strip&.split("\n") || []
             step_document_links = row[24]&.strip&.split("\n") || []

--- a/lib/ssj/workflow/import.rb
+++ b/lib/ssj/workflow/import.rb
@@ -134,9 +134,9 @@ module SSJ
         return 0 if value.blank?
         return 0 if unit.blank?
 
-        if unit.contains?("min")
+        if unit.include?("min")
           value.to_i
-        elsif unit.contains?("hour")
+        elsif unit.include?("hour")
           value.to_i * 60
         else
           raise "unknown time unit #{unit}"

--- a/lib/ssj/workflow/import.rb
+++ b/lib/ssj/workflow/import.rb
@@ -49,12 +49,13 @@ module SSJ
             puts "creating #{process_title}"
             process_description = row[15]&.strip
             process_start_considering = row[5]&.strip.present?
-            process_weight = row[19]&.strip # convert to integer
-            process_effort = {S: "small", M: "medium", L: "large"}[process_weight.to_s.to_sym]
+            process_min_worktime = convert_to_minutes(row[19]&.strip, row[21]&.strip)
+            process_max_worktime = convert_to_minutes(row[20]&.strip, row[21]&.strip)
+
             process_category = row[7]&.strip
             process_position += ::Workflow::Definition::Process::DEFAULT_INCREMENT
 
-            process_obj = ::Workflow::Definition::Process.create! version: default_version, title: process_title, description: process_description, effort: process_effort, position: process_position, category_list: process_category, start_considering: process_start_considering
+            process_obj = ::Workflow::Definition::Process.create! version: default_version, title: process_title, description: process_description, min_worktime: process_min_worktime, max_worktime: process_max_worktime, position: process_position, category_list: process_category, start_considering: process_start_considering
 
             step_position = 0
           elsif process_title.blank? && step_title.present?
@@ -65,12 +66,12 @@ module SSJ
             step_position += ::Workflow::Definition::Step::DEFAULT_INCREMENT
             step = process_obj.steps.create!(title: step_title, description: step_description, kind: step_type, position: step_position)
 
-            step_documents = row[21]&.strip&.split("\n")
-            step_type = row[22]&.strip&.split("\n")
-            step_documents&.each_with_index do |link, i|
-              step.documents.create!(title: step_type[i], link: link)
+            step_document_titles = row[23]&.strip&.split("\n") || []
+            step_document_links = row[24]&.strip&.split("\n") || []
+            step_document_types = row[25]&.strip&.split("\n") || []
+            step_document_links&.each_with_index do |link, i|
+              step.documents.create!(title: step_document_titles[i] || step_document_types[i], link: link)
             end
-            # create resources for steps.  document attaches via polymorphic.  step needs to have that code injected.
           else
             # empty line
             puts "empty line"
@@ -127,6 +128,19 @@ module SSJ
           200_000
         when "startup"
           300_000
+        end
+      end
+
+      def convert_to_minutes(value, unit)
+        return 0 if value.blank?
+        return 0 if unit.blank?
+
+        if unit.contains?("min")
+          value.to_i
+        elsif unit.contains?("hour")
+          value.to_i * 60
+        else
+          raise "unknown time unit #{unit}"
         end
       end
     end

--- a/lib/ssj/workflow/import.rb
+++ b/lib/ssj/workflow/import.rb
@@ -2,6 +2,8 @@
 # look at this sheet to understand what's happening
 # https://docs.google.com/spreadsheets/d/1cXGliig-PGosbGyY9Jp30me2WasNN65yitJGvxRGB4k/edit#gid=294865209
 
+# To make updates, you have to update the dropbox links at the bottom and run #create_default_workflow_and_processes.
+
 require 'csv'
 require 'workflow/definition/process'
 
@@ -34,7 +36,7 @@ module SSJ
       end
 
       def import_process_library
-        # build processes library, having the admin will help... don't worry about position yet.  leverage the fact it is definition 0.
+        # build processes library, having the admin UI will help but using importer for now.
         process_obj = nil
         process_position = default_process_position
         step_position = 0
@@ -46,12 +48,13 @@ module SSJ
           if process_title.present?
             puts "creating #{process_title}"
             process_description = row[15]&.strip
+            process_start_considering = row[5]&.strip.present?
             process_weight = row[19]&.strip # convert to integer
             process_effort = {S: "small", M: "medium", L: "large"}[process_weight.to_s.to_sym]
             process_category = row[7]&.strip
             process_position += ::Workflow::Definition::Process::DEFAULT_INCREMENT
 
-            process_obj = ::Workflow::Definition::Process.create! version: default_version, title: process_title, description: process_description, effort: process_effort, position: process_position, category_list: process_category
+            process_obj = ::Workflow::Definition::Process.create! version: default_version, title: process_title, description: process_description, effort: process_effort, position: process_position, category_list: process_category, start_considering: process_start_considering
 
             step_position = 0
           elsif process_title.blank? && step_title.present?

--- a/spec/serializers/v1/workflow/process_serializer_spec.rb
+++ b/spec/serializers/v1/workflow/process_serializer_spec.rb
@@ -1,0 +1,13 @@
+
+require 'rails_helper'
+
+describe V1::Workflow::ProcessSerializer do
+  let(:process) { build(:workflow_instance_process, steps_count: 1) }
+
+  subject { described_class.new(process).as_json }
+
+  it "should serialize properly" do
+    expect(json_document['data']).to have_jsonapi_attributes(:title, :effort, :position, :stepsCount, :completedStepsCount, :description, :phaseList, :status, :categories, :stepsAssignedCount)
+    expect(json_document['data']).to have_relationships(:steps, :workflow)
+  end
+end

--- a/spec/serializers/v1/workflow/step_serializer_spec.rb
+++ b/spec/serializers/v1/workflow/step_serializer_spec.rb
@@ -15,7 +15,7 @@ describe V1::Workflow::StepSerializer do
 
   it "should serialize properly" do
     expect(json_document['data']).to have_relationships(:process, :documents)
-    expect(json_document['data']).to have_jsonapi_attributes(:completed, :completedAt, :decisionOptions, :kind, :position, :title, :min_worktime, :max_worktime)
+    expect(json_document['data']).to have_jsonapi_attributes(:completed, :completedAt, :decisionOptions, :kind, :position, :title, :minWorktime, :maxWorktime)
     expect(json_document['data']). to have_jsonapi_attributes(:assigneeInfo)
   end
 end

--- a/spec/serializers/v1/workflow/step_serializer_spec.rb
+++ b/spec/serializers/v1/workflow/step_serializer_spec.rb
@@ -15,7 +15,7 @@ describe V1::Workflow::StepSerializer do
 
   it "should serialize properly" do
     expect(json_document['data']).to have_relationships(:process, :documents)
-    expect(json_document['data']).to have_jsonapi_attributes(:completed, :completedAt, :decisionOptions, :kind, :position, :title)
+    expect(json_document['data']).to have_jsonapi_attributes(:completed, :completedAt, :decisionOptions, :kind, :position, :title, :min_worktime, :max_worktime)
     expect(json_document['data']). to have_jsonapi_attributes(:assigneeInfo)
   end
 end


### PR DESCRIPTION
- Remove `effort` from process and replace with step level `min_worktime` and `max_worktime`
- Fixes a bug for importing resources