### PR TITLE
Don't include assignee info for self_assigned=true request

### DIFF
--- a/app/controllers/v1/workflow/processes_controller.rb
+++ b/app/controllers/v1/workflow/processes_controller.rb
@@ -29,7 +29,7 @@ class V1::Workflow::ProcessesController < ApiController
       processes = processes.select do |process|
         process.steps.where(assignee_id: current_user.person_id, completed: false).count > 0
       end
-      options[:params] = { assignee_id: current_user.person_id }
+      options[:params] = { assignee_id: current_user.person_id, self_assigned: true }
     end
 
     render json: V1::Workflow::ProcessSerializer.new(processes, options)

--- a/app/serializers/v1/workflow/step_serializer.rb
+++ b/app/serializers/v1/workflow/step_serializer.rb
@@ -35,10 +35,10 @@ class V1::Workflow::StepSerializer < ApplicationSerializer
     step.definition&.max_worktime
   end
 
+
   # bit of a hack so we can have assignee information when the step serializer is nested in the process serializer
-  attribute :assignee_info do |step, params|
-    if assignee = !params[:basic] && step.assignee
-      { id: assignee.external_identifier, imageUrl: assignee.image_url }
-    end
+  attribute :assignee_info, if: Proc.new {|step, params| !params[:self_assigned] && !params[:basic] && step.assignee } do |step|
+    assignee = step.assignee
+    { id: assignee.external_identifier, imageUrl: assignee.image_url }
   end
 end

--- a/spec/requests/v1/workflow/processes_spec.rb
+++ b/spec/requests/v1/workflow/processes_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe "V1::Workflow::Processes", type: :request do
       expect(json_response["data"]).to have_type(:process).and have_attribute(:status)
       expect(json_response["data"]).to have_type(:process).and have_attribute(:stepsCount)
       expect(json_response["data"]).to have_type(:process).and have_attribute(:completedStepsCount)
+      step_obj = json_response["included"].select{|obj| obj["type"] == "step"}.last
+      expect(step_obj).to have_attribute(:assigneeInfo)
     end
   end
 

--- a/spec/requests/v1/workflow/processes_spec.rb
+++ b/spec/requests/v1/workflow/processes_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe "V1::Workflow::Processes", type: :request do
       expect(steps.length).to eq(1)
       expect(steps[0]["id"]).to_not eq(unassigned_step.external_identifier)
       expect(steps[0]["id"]).to eq(assigned_step.external_identifier)
+      step_obj = json_response["included"].select{|obj| obj["type"] == "step"}.last
+      expect(step_obj).not_to have_attribute(:assigneeInfo)
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/Me8khZk9/141-dont-include-assignee-object-in-attributes-response-for-self-assignedtrue

Clean up serializer so we don't have redundant data