### PR TITLE
Refresh database for integration tests

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 FRONTEND_URL="http://localhost:3000"
 S3_BUCKET="ssj-local"
+CYPRESS_ENABLED=true

--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -1,17 +1,24 @@
 class TestController < ApplicationController
   def reset_fixtures
     user = User.find_by(email: 'cypress_test@test.com')
-    ## clean deletion of everything
 
     ActiveRecord::Base.transaction do
-      if person = user && user.person
+      # delete everything associated to this user
+      person = user.person
+      user.destroy!
+      if person
         person.address&.destroy!
         person.profile_image&.purge
 
         ssj_team = person.ssj_team
-        ssj_team.partner_members.each do |partner_member|
-          partner_member.person&.destroy! # person and any partners will be destroyed
-          partner_member.destroy!
+        ssj_team.ops_guide = nil
+        ssj_team.regional_growth_lead_id = nil
+        ssj_team.save!
+
+        ssj_team.team_members.each do |team_member|
+          User.where(person_id: team_member.person_id).destroy_all
+          team_member.person&.destroy!
+          team_member.destroy!
         end
         ssj_team.destroy!
       
@@ -23,23 +30,22 @@ class TestController < ApplicationController
           process.destroy!
         end
         workflow_instance.destroy!
+
+        # create clean user, person and workflow
+        user = User.create!(email: 'cypress_test@test.com', password: 'password')
+        person = Person.create!
+        user.person = person
+        user.save!
+        Address.create!(addressable: person) if person.address.nil?
+        
+        ops_guide = FactoryBot.create(:person, role_list: "ops_guide")
+        workflow_definition = Workflow::Definition::Workflow.find_by(name: "Basic Workflow")
+        workflow_instance = SSJ::Initialize.run(workflow_definition)
+        ssj_team = SSJ::Team.create!(workflow: workflow_instance, ops_guide_id: ops_guide.id)
+
+        SSJ::TeamMember.create(person: ops_guide, ssj_team: ssj_team, role: SSJ::TeamMember::OPS_GUIDE, status: SSJ::TeamMember::ACTIVE)
+        SSJ::TeamMember.create!(person_id: person.id, ssj_team_id: ssj_team.id, role: SSJ::TeamMember::PARTNER, status: SSJ::TeamMember::ACTIVE)
       end
-
-
-      # create clean person and team member
-      user = User.create!(email: 'cypress_test@test.com', password: 'password') if user.nil?
-      person = Person.create!
-      user.person = person
-      user.save!
-      Address.create!(addressable: person) if person.address.nil?
-      
-      ops_guide = FactoryBot.create(:person, role_list: "ops_guide")
-      workflow_definition = Workflow::Definition::Workflow.find_by(name: "Basic Workflow")
-      workflow_instance = SSJ::Initialize.run(workflow_definition)
-      ssj_team = SSJ::Team.create!(workflow: workflow_instance, ops_guide_id: ops_guide.id)
-
-      SSJ::TeamMember.create(person: ops_guide, ssj_team: ssj_team, role: SSJ::TeamMember::OPS_GUIDE, status: SSJ::TeamMember::ACTIVE)
-      SSJ::TeamMember.create!(person_id: person.id, ssj_team_id: ssj_team.id, role: SSJ::TeamMember::PARTNER, status: SSJ::TeamMember::ACTIVE)
     end
   end
 end

--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -25,6 +25,9 @@ class TestController < ApplicationController
         workflow_instance = ssj_team.workflow
         workflow_instance.processes.each do |process|
           process.steps.each do |step|
+            step.assignments.each do |assignment|
+              assignment.destroy!
+            end
             step.destroy!
           end
           process.destroy!
@@ -33,7 +36,7 @@ class TestController < ApplicationController
 
         # create clean user, person and workflow
         user = User.create!(email: 'cypress_test@test.com', password: 'password')
-        person = Person.create!
+        person = Person.create!(image_url: 'https://en.gravatar.com/userimage/4310496/6924cffc6c2e516293c1e8b6e7533ab5.jpg')
         user.person = person
         user.save!
         Address.create!(addressable: person) if person.address.nil?

--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -1,0 +1,45 @@
+class TestController < ApplicationController
+  def reset_fixtures
+    user = User.find_by(email: 'cypress_test@test.com')
+    ## clean deletion of everything
+
+    ActiveRecord::Base.transaction do
+      if person = user && user.person
+        person.address&.destroy!
+        person.profile_image&.purge
+
+        ssj_team = person.ssj_team
+        ssj_team.partner_members.each do |partner_member|
+          partner_member.person&.destroy! # person and any partners will be destroyed
+          partner_member.destroy!
+        end
+        ssj_team.destroy!
+      
+        workflow_instance = ssj_team.workflow
+        workflow_instance.processes.each do |process|
+          process.steps.each do |step|
+            step.destroy!
+          end
+          process.destroy!
+        end
+        workflow_instance.destroy!
+      end
+
+
+      # create clean person and team member
+      user = User.create!(email: 'cypress_test@test.com', password: 'password') if user.nil?
+      person = Person.create!
+      user.person = person
+      user.save!
+      Address.create!(addressable: person) if person.address.nil?
+      
+      ops_guide = FactoryBot.create(:person, role_list: "ops_guide")
+      workflow_definition = Workflow::Definition::Workflow.find_by(name: "Basic Workflow")
+      workflow_instance = SSJ::Initialize.run(workflow_definition)
+      ssj_team = SSJ::Team.create!(workflow: workflow_instance, ops_guide_id: ops_guide.id)
+
+      SSJ::TeamMember.create(person: ops_guide, ssj_team: ssj_team, role: SSJ::TeamMember::OPS_GUIDE, status: SSJ::TeamMember::ACTIVE)
+      SSJ::TeamMember.create!(person_id: person.id, ssj_team_id: ssj_team.id, role: SSJ::TeamMember::PARTNER, status: SSJ::TeamMember::ACTIVE)
+    end
+  end
+end

--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -10,17 +10,18 @@ class TestController < ApplicationController
         person.address&.destroy!
         person.profile_image&.purge
 
-        ssj_team = person.ssj_team
-        ssj_team.ops_guide = nil
-        ssj_team.regional_growth_lead_id = nil
-        ssj_team.save!
+        if ssj_team = person.ssj_team
+          ssj_team.ops_guide_id = nil
+          ssj_team.regional_growth_lead_id = nil
+          ssj_team.save!
 
-        ssj_team.team_members.each do |team_member|
-          User.where(person_id: team_member.person_id).destroy_all
-          team_member.person&.destroy!
-          team_member.destroy!
+          ssj_team.team_members.each do |team_member|
+            User.where(person_id: team_member.person_id).destroy_all
+            team_member.person&.destroy!
+            team_member.destroy!
+          end
+          ssj_team.destroy!
         end
-        ssj_team.destroy!
       
         workflow_instance = ssj_team.workflow
         workflow_instance.processes.each do |process|

--- a/app/serializers/v1/school_serializer.rb
+++ b/app/serializers/v1/school_serializer.rb
@@ -9,7 +9,7 @@ module V1
       school.pod
     end
     has_many :school_relationships, id_method_name: :external_identifier do |school|
-      school.school_relationships
+      school.school_relationships.includes([:person])
     end
     has_many :people, id_method_name: :external_identifier do |school|
       school.people

--- a/app/serializers/v1/school_serializer.rb
+++ b/app/serializers/v1/school_serializer.rb
@@ -9,7 +9,7 @@ module V1
       school.pod
     end
     has_many :school_relationships, id_method_name: :external_identifier do |school|
-      school.school_relationships.includes([:person])
+      school.school_relationships
     end
     has_many :people, id_method_name: :external_identifier do |school|
       school.people

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,4 +92,6 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  put 'reset_fixtures', to: 'test#reset_fixtures' if ENV['CYPRESS_ENABLED'] == 'true'
 end


### PR DESCRIPTION
Creates an endpoint that deletes test objects and recreates new ones. Endpoint is only accessible when `CYPRESS_ENABLED` is set to `true`. 