### PR TITLE
Fix airtable update typo

### DIFF
--- a/app/services/network/update_airtable_records.rb
+++ b/app/services/network/update_airtable_records.rb
@@ -47,7 +47,6 @@ class Network::UpdateAirtableRecords < BaseCommand
 
   def people_fields(person)
     {
-      :blah => "blah",
       :first_name => person.first_name,
       :middle_name => person.middle_name,
       :last_name => person.last_name,

--- a/app/services/network/update_airtable_records.rb
+++ b/app/services/network/update_airtable_records.rb
@@ -42,6 +42,7 @@ class Network::UpdateAirtableRecords < BaseCommand
       Rails.logger.info("Finished syncing #{name} creates/updates to Airtable; #{updates} updates, #{creates} creates")
     rescue => e
       Rails.logger.error("Error syncing #{name} creates/updates to Airtable; #{updates} updates, #{creates} creates completed. Error: #{e.message}.")
+      raise e
     end
   end
 


### PR DESCRIPTION
Remove erroneous field "blah" and also raise error so cron job fails if there's an issue.