### PR TITLE
Tweaks to cron job and bullet errors

### DIFF
--- a/app/controllers/v1/ssj/teams_controller.rb
+++ b/app/controllers/v1/ssj/teams_controller.rb
@@ -13,7 +13,7 @@ class V1::SSJ::TeamsController < ApiController
   end
 
   def show
-    if team = SSJ::Team.find_by!(external_identifier: params[:id])
+    if team = SSJ::Team.includes([partner_members: [person: [:hub, :profile_image_attachment, :schools, :school_relationships, taggings: [:tag]]]]).find_by!(external_identifier: params[:id])
       render json: V1::SSJ::TeamSerializer.new(team, team_options)
     else
       render json: { message: "current user is not part of team"}, status: :unprocessable_entity

--- a/app/jobs/cleanup_test_fixtures_job.rb
+++ b/app/jobs/cleanup_test_fixtures_job.rb
@@ -4,7 +4,7 @@ class CleanupTestFixturesJob < ActiveJob::Base
   queue_as :default
 
   def perform
-    User.where("lower(email) like ? OR lower(email) like ?", "cypress_test%", "newemail%").each do |user|
+    User.where("lower(email) like ? OR lower(email) like ?", "cypress_test%", "newemail%").limit(25).each do |user|
       begin
         person = user&.person
         user&.destroy! 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -61,4 +61,4 @@ if ENV.fetch('RAILS_ENV') == 'staging'
   at_exit do
     GoodJob.shutdown if Process.pid == MAIN_PID
   end
-end
+# d# 


### PR DESCRIPTION
- Update GET /team/[id] to make it more efficient
- limit cleanup fixture job to only delete 25 users every 15 minutes.