### PR TITLE
Move cron job to background worker

### DIFF
--- a/app/jobs/update_airtable_job.rb
+++ b/app/jobs/update_airtable_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class UpdateAirtableJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    Network::UpdateAirtableRecords.call()
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,11 +93,11 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Enable cron in staging 
+  # Enable cron in production
   config.good_job.enable_cron = true
   # schedule cron job like jobs via good_job gem
   config.good_job.cron = {
-    # Every 15 minutes, enqueue `CleanupTestFixturesJob.set(priority: -10).perform_later()`
+    # Every day, enqueue `UpdateAirtableJob.set(priority: -10).perform_later()`
     cleanup_fixture_task: { # each recurring job must have a unique key
       cron: "0 15 * * *", # cron-style scheduling format by fugit gem
       class: "UpdateAirtableJob", # name of the job class as a String; must reference an Active Job job class

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,6 +92,19 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Enable cron in staging 
+  config.good_job.enable_cron = true
+  # schedule cron job like jobs via good_job gem
+  config.good_job.cron = {
+    # Every 15 minutes, enqueue `CleanupTestFixturesJob.set(priority: -10).perform_later()`
+    cleanup_fixture_task: { # each recurring job must have a unique key
+      cron: "0 15 * * *", # cron-style scheduling format by fugit gem
+      class: "UpdateAirtableJob", # name of the job class as a String; must reference an Active Job job class
+      set: { priority: -10 }, # additional Active Job properties; can also be a lambda/proc e.g. `-> { { priority: [1,2].sample } }`
+      description: "Update airtable records by sending new and updated records to it", # optional description that appears in Dashboard
+    },
+  }
 end
 
 ActionMailer::Base.smtp_settings = {

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -43,22 +43,3 @@ pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
-
-if ENV.fetch('RAILS_ENV') == 'staging'
-  before_fork do
-    GoodJob.shutdown
-  end
-
-  on_worker_boot do
-    GoodJob.restart
-  end
-
-  on_worker_shutdown do
-    GoodJob.shutdown
-  end
-
-  MAIN_PID = Process.pid
-  at_exit do
-    GoodJob.shutdown if Process.pid == MAIN_PID
-  end
-end 


### PR DESCRIPTION
Moving airtable cron job onto background worker that uses `good_job` gem. This will enable us to remove a server in production.