### PR TITLE
Change step definition serializer to use external identifier for Document

### DIFF
--- a/app/serializers/v1/workflow/definition/step_serializer.rb
+++ b/app/serializers/v1/workflow/definition/step_serializer.rb
@@ -7,7 +7,7 @@ class V1::Workflow::Definition::StepSerializer < ApplicationSerializer
     step.decision_options
   end
 
-  has_many :documents, serializer: V1::DocumentSerializer do |step|
+  has_many :documents, serializer: V1::DocumentSerializer, id_method_name: :external_identifier do |step|
     step.documents
   end
 end


### PR DESCRIPTION
```
.....{
  "data": {
    "id": "2399",
    "type": "step",
    "attributes": {
      "title": "Updated Step",
      "description": "This is an updated step",
      "kind": "decision",
      "position": 2,
      "completionType": "one_per_group",
      "decisionQuestion": "Are you sure?",
      "minWorktime": 190800,
      "maxWorktime": 493200
    },
    "relationships": {
      "decisionOptions": {
        "data": [

        ]
      },
      "documents": {
        "data": [
          {
            "id": "7e01-6966",
            "type": "document"
          }
        ]
      }
    }
  },
  "included": [
    {
      "id": "7e01-6966",
      "type": "document",
      "attributes": {
        "inheritanceType": null,
        "title": "Look Homeward, Angel",
        "link": "http://kshlerin-treutel.info/mireille",
        "updatedAt": "2024-03-04T17:23:35.866Z"
      }
    }
  ]
}
```