### PR TITLE
Lots of tweaks

### DIFF
--- a/app/controllers/v1/workflow/definition/selected_processes_controller.rb
+++ b/app/controllers/v1/workflow/definition/selected_processes_controller.rb
@@ -1,10 +1,31 @@
 class V1::Workflow::Definition::SelectedProcessesController < ApiController
   before_action :authenticate_admin!
 
+  # For now, only use this endpoint for position updates
+  def update
+    selected_process = Workflow::Definition::SelectedProcess.find(params[:id])
+
+    if selected_process.replicated? && !selected_process.workflow.published?
+      selected_process.update!(selected_process_params)
+      selected_process.reposition!
+      render json: V1::Workflow::Definition::SelectedProcessSerializer.new(selected_process.reload)
+    else
+      render json: 
+        { error: "Selected process state: #{selected_process.state}, workflow published: #{selected_process.workflow.published?}" }, 
+        status: :unprocessable_entity
+    end
+  end
+
   def revert
     selected_process = Workflow::Definition::SelectedProcess.find(params[:selected_process_id])
     selected_process.revert!
 
     render json: V1::Workflow::Definition::SelectedProcessSerializer.new(selected_process)
+  end
+
+  private
+
+  def selected_process_params
+    params.require(:selected_process).permit(:position)
   end
 end

--- a/app/controllers/v1/workflow/definition/workflows_controller.rb
+++ b/app/controllers/v1/workflow/definition/workflows_controller.rb
@@ -73,9 +73,13 @@ class V1::Workflow::Definition::WorkflowsController < ApiController
   def add_process
     workflow = Workflow::Definition::Workflow.find(params[:workflow_id])
     process = Workflow::Definition::Process.find(params[:process_id])
+    position = nil
+    if process_params[:selected_processes_attributes]
+      position = process_params[:selected_processes_attributes].last[:position]
+    end
 
     begin
-      Workflow::Definition::Workflow::AddProcess.run(workflow, process)
+      Workflow::Definition::Workflow::AddProcess.run(workflow, process, position)
     rescue Exception => e
       log_error(e)
       render json: { error: e.message }, status: :unprocessable_entity

--- a/app/models/workflow/definition/selected_process.rb
+++ b/app/models/workflow/definition/selected_process.rb
@@ -16,7 +16,7 @@ module Workflow
 
     aasm column: :state do
       state :initialized, initial: true 
-      state :replicated, :removed, :upgraded, :added
+      state :replicated, :removed, :upgraded, :added, :repositioned
     
       event :replicate do
         transitions from: :initialized, to: :replicated
@@ -26,11 +26,15 @@ module Workflow
         transitions from: :replicated, to: :removed
       end
     
+      event :reposition do
+        transitions from: :replicated, to: :repositioned
+      end
+    
       event :revert do
         before do
           revert_to_previous_version
         end
-        transitions from: [:removed, :upgraded], to: :replicated
+        transitions from: [:removed, :upgraded, :repositioned], to: :replicated
       end
     
       event :upgrade do
@@ -62,6 +66,7 @@ module Workflow
       end
 
       self.process = previous_version&.process
+      self.position = previous_version&.position
     end
   end
 end

--- a/app/models/workflow/definition/workflow.rb
+++ b/app/models/workflow/definition/workflow.rb
@@ -23,6 +23,14 @@ module Workflow
       !published_at.nil?
     end
   
+    def displayed_processes
+      if published?
+        processes.joins(:selected_processes).where.not("workflow_definition_selected_processes.state = ?", 'removed')
+      else
+        processes
+      end
+    end
+  
     private
 
     def check_published

--- a/app/serializers/v1/workflow/definition/workflow_serializer.rb
+++ b/app/serializers/v1/workflow/definition/workflow_serializer.rb
@@ -20,6 +20,6 @@ class V1::Workflow::Definition::WorkflowSerializer < ApplicationSerializer
   end
   
   has_many :processes, serializer: V1::Workflow::Definition::BasicProcessSerializer do |workflow, params|
-    workflow.processes.includes(:taggings, :categories).order(:position)
+    workflow.displayed_processes.includes(:taggings, :categories).order(:position)
   end
 end

--- a/app/services/workflow/definition/process/new_version.rb
+++ b/app/services/workflow/definition/process/new_version.rb
@@ -6,6 +6,7 @@ module Workflow
           @workflow = workflow
           @process = process
           @new_version = nil
+          @selected_process = ::Workflow::Definition::SelectedProcess.find_by!(workflow_id: @workflow.id, process_id: @process.id)
         end
       
         def run
@@ -26,6 +27,10 @@ module Workflow
          
           if @workflow.published?
             raise Error.new("workflow cannot be published")
+          end
+          
+          if @selected_process.repositioned?
+            raise Error.new("process cannot have changed position beforehand")
           end
         end
 
@@ -70,10 +75,9 @@ module Workflow
         end
       
         def update_selected_process
-          selected_process = ::Workflow::Definition::SelectedProcess.find_by!(workflow_id: @workflow.id, process_id: @process.id)
-          selected_process.process_id = @new_version.id
-          selected_process.upgrade!
-          selected_process.save!
+          @selected_process.process_id = @new_version.id
+          @selected_process.upgrade!
+          @selected_process.save!
         end
       end
     end

--- a/app/services/workflow/definition/workflow/add_process.rb
+++ b/app/services/workflow/definition/workflow/add_process.rb
@@ -3,9 +3,10 @@ module Workflow
     class Workflow
       # Add a process to workflow
       class AddProcess < BaseService
-        def initialize(workflow, process)
+        def initialize(workflow, process, position)
           @workflow = workflow
           @process = process
+          @position = position
         end
       
         def run
@@ -22,7 +23,7 @@ module Workflow
         end
       
         def create_association
-          sp = ::Workflow::Definition::SelectedProcess.create!(workflow_id: @workflow.id, process_id: @process.id)
+          sp = ::Workflow::Definition::SelectedProcess.create!(workflow_id: @workflow.id, process_id: @process.id, position: @position)
           sp.add!
           return sp
         end

--- a/app/services/workflow/definition/workflow/remove_process.rb
+++ b/app/services/workflow/definition/workflow/remove_process.rb
@@ -43,6 +43,7 @@ module Workflow
             @selected_process.remove!
           else
             raise RemoveProcessError.new("selected process is in an invalid state to be removed")
+            # Note if a selected process is repositioned, it cannot be removed because the checks for propogating a removal depends on position
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,7 @@ Rails.application.routes.draw do
         end
         # resources :steps, only: [:index, :show, :create, :update, :destroy]
         resources :dependencies, only: [:destroy]
-        resources :selected_processes do
+        resources :selected_processes, only: [:update] do
           put '/revert', to: 'selected_processes#revert'
         end
       end

--- a/spec/models/workflow/definition/selected_process_spec.rb
+++ b/spec/models/workflow/definition/selected_process_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Workflow::Definition::SelectedProcess, type: :model do
   describe "#revert" do
-    let(:previous_version) { create(:selected_process) }
+    let(:previous_version) { create(:selected_process, position: 100) }
 
-    context "when the process is upgraded" do
+    context "when the selected process is upgraded" do
       let(:selected_process) { create(:selected_process, previous_version: previous_version) }
 
       before do
@@ -19,7 +19,7 @@ RSpec.describe Workflow::Definition::SelectedProcess, type: :model do
       end
     end
 
-    context "when process is removed" do
+    context "when selected process is removed" do
       let(:selected_process) { create(:selected_process, process: previous_version.process, previous_version: previous_version) }
 
       before do
@@ -31,6 +31,22 @@ RSpec.describe Workflow::Definition::SelectedProcess, type: :model do
         expect { selected_process.revert! }.to change { Workflow::Definition::Process.count }.by(0)
         expect(selected_process.process).to eq(previous_version.process)
         expect(selected_process.replicated?).to be true
+      end
+    end
+
+    context "when selected process is repositioned" do
+      let(:selected_process) { create(:selected_process, process: previous_version.process, previous_version: previous_version, position: 200) }
+
+      before do
+        selected_process.replicate!
+        selected_process.reposition!
+      end
+
+      it "sets state back to replicated, and reverts position" do
+        expect { selected_process.revert! }.to change { Workflow::Definition::Process.count }.by(0)
+        expect(selected_process.process).to eq(previous_version.process)
+        expect(selected_process.replicated?).to be true
+        expect(selected_process.position).to eq(previous_version.position)
       end
     end
 

--- a/spec/requests/v1/workflow/definition/selected_processes_spec.rb
+++ b/spec/requests/v1/workflow/definition/selected_processes_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "V1::Workflow::Definition::SelectedProcesses", type: :request do
+  let(:admin) { create(:user, :admin) }
   describe "POST /v1/workflow/definition/selected_processes/:id/revert" do
-    let(:admin) { create(:user, :admin) }
     let(:previous_version) { create(:selected_process, state: 'initialized') }
     let(:selected_process) { create(:selected_process, state: 'upgraded', previous_version: previous_version) }
 
@@ -16,6 +16,61 @@ RSpec.describe "V1::Workflow::Definition::SelectedProcesses", type: :request do
       expect(response).to have_http_status(200)
       expect(selected_process.reload).to be_replicated
       expect(selected_process.process_id).to eq(previous_version.process_id)
+    end
+  end
+
+  describe 'PUT /v1/workflow/definition/selected_processes/:selected_process_id' do
+    let(:selected_process) { create(:selected_process, workflow: workflow) }
+    let(:workflow) { create(:workflow_definition_workflow, published_at: nil) }
+
+    before do
+      sign_in(admin)
+    end
+
+    context 'when selected process is replicated and workflow is not published' do
+      before do
+        selected_process.update(state: 'replicated')
+        put "/v1/workflow/definition/selected_processes/#{selected_process.id}", params: { selected_process: { position: 200 } }
+      end
+
+      it 'updates the selected process' do
+        expect(response).to have_http_status(:success)
+        expect(selected_process.reload.position).to eq(200)
+      end
+
+      it 'repositions the selected process' do
+        expect(selected_process.reload.state).to eq('repositioned')
+      end
+
+      it 'returns the updated selected process as JSON' do
+        json_response = JSON.parse(response.body)
+        expect(json_response['data']['id']).to eq(selected_process.id.to_s)
+        expect(json_response['data']['attributes']['position']).to eq(200)
+      end
+    end
+
+    context 'when selected process is not replicated' do
+      before do
+        put "/v1/workflow/definition/selected_processes/#{selected_process.id}", params: { selected_process: { position: 200 } }
+      end
+
+      it 'returns an error message' do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)['error']).to eq('Selected process state: initialized, workflow published: false')
+      end
+    end
+
+    context 'when workflow is published' do
+      before do
+        workflow.update(published_at: DateTime.now)
+        selected_process.update(state: 'replicated')
+        put "/v1/workflow/definition/selected_processes/#{selected_process.id}", params: { selected_process: { position: 200 } }
+      end
+
+      it 'returns an error message' do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)['error']).to eq('Selected process state: replicated, workflow published: true')
+      end
     end
   end
 end

--- a/spec/services/workflow/definition/workflow/add_process_spec.rb
+++ b/spec/services/workflow/definition/workflow/add_process_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Workflow::Definition::Workflow::AddProcess do
     let(:workflow) { create(:workflow_definition_workflow) }
     let(:process) { create(:workflow_definition_process) }
     let!(:selected_process) { create(:selected_process, workflow: workflow, process: process) }
-    let(:subject) { Workflow::Definition::Workflow::AddProcess.new(workflow, process) }
+    let(:subject) { Workflow::Definition::Workflow::AddProcess.new(workflow, process, 50) }
 
     context "workflow is published" do
       let(:workflow) { create(:workflow_definition_workflow, published_at: DateTime.now) }


### PR DESCRIPTION
-  bug fix for adding a new process but the position doesn't work
- update workflow serializer to only show displayed processes, which is conditional on if workflow is published
- new state for selected process, "reposition"
- new endpoint for updating position of only processes of a workflow in draft mode