### PR TITLE
More bug fixes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---require spec_helper
+--require spec_helper --profile 10

--- a/app/controllers/v1/workflow/definition/steps_controller.rb
+++ b/app/controllers/v1/workflow/definition/steps_controller.rb
@@ -23,6 +23,9 @@ class V1::Workflow::Definition::StepsController < ApiController
         return render json: { message: e.message }, status: :bad_request
       end
     else
+      if (step_params[:position].to_i.to_s != step_params[:position]) || (step_params[:position].to_i == 0)
+        return render json: { message: "position must be an integer greater than 0", status: :bad_request}
+      end
       step.update!(step_params)
     end
 

--- a/app/services/workflow/definition/workflow/create_dummy.rb
+++ b/app/services/workflow/definition/workflow/create_dummy.rb
@@ -11,14 +11,14 @@ module Workflow
 
           # Visioning
           process1 = FactoryBot.create(:workflow_definition_process, title: "Milestone A", description: "A single milestone with 3 steps", version: "v1")
-          3.times { |i| FactoryBot.create(:workflow_definition_step, process: process1, title: "Step #{i+1}", description: "Step #{i+1} of 3", position: i * ::Workflow::Definition::Step::DEFAULT_INCREMENT) }
+          3.times { |i| FactoryBot.create(:workflow_definition_step, process: process1, title: "Step #{i+1}", description: "Step #{i+1} of 3") }
           
           process2 = FactoryBot.create(:workflow_definition_process, title: "Milestone B-1", description: "A sequential milestone: B-1 then B-2", version: "v1")
           decision_step = FactoryBot.create(:workflow_definition_step, process: process2, title: "Decision Step 1", description: "A single decision step with 3 options", kind: ::Workflow::Definition::Step::DECISION, position: ::Workflow::Definition::Step::DEFAULT_INCREMENT)
           3.times { |i| FactoryBot.create(:workflow_decision_option, decision: decision_step, description: "Option #{i+1}") }
           
           process3 = FactoryBot.create(:workflow_definition_process, title: "Milestone B-2", description: "The second milestone B-2 should be worked on after B-1 is done.", version: "v1")
-          2.times { |i| FactoryBot.create(:workflow_definition_step, process: process3, title: "Step #{i+1}", description: "Step #{i+1} of 2", position: i * ::Workflow::Definition::Step::DEFAULT_INCREMENT) }
+          2.times { |i| FactoryBot.create(:workflow_definition_step, process: process3, title: "Step #{i+1}", description: "Step #{i+1} of 2") }
           
           [process1, process2, process3].each_with_index do |process, i|
             workflow_definition.processes << process
@@ -38,7 +38,7 @@ module Workflow
           4.times { |i| FactoryBot.create(:workflow_decision_option, decision: decision_step, description: "Option #{i+1}") }
           
           process6 = FactoryBot.create(:workflow_definition_process, title: "Milestone C-Y", description: "This milestone gets unlocked after C is done.", version: "v1")
-          2.times { |i| FactoryBot.create(:workflow_definition_step, process: process6, title: "Step #{i+1}", description: "Step #{i+1} of 2", position: i * ::Workflow::Definition::Step::DEFAULT_INCREMENT) }
+          2.times { |i| FactoryBot.create(:workflow_definition_step, process: process6, title: "Step #{i+1}", description: "Step #{i+1} of 2") }
           
           [process4, process5, process6].each_with_index do |process, i|
             workflow_definition.processes << process
@@ -52,13 +52,13 @@ module Workflow
           
           # Startup
           process7 = FactoryBot.create(:workflow_definition_process, title: "Milestone D", description: "A milestone that is 1 of 2 pre-requisites for Milestone D-E-F", version: "v1")
-          1.times { |i| FactoryBot.create(:workflow_definition_step, process: process7, title: "Step #{i+1}", description: "A single step", position: i*::Workflow::Definition::Step::DEFAULT_INCREMENT) }
+          1.times { |i| FactoryBot.create(:workflow_definition_step, process: process7, title: "Step #{i+1}", description: "A single step") }
           
           process8 = FactoryBot.create(:workflow_definition_process, title: "Milestone E", description: "A milestone that is 1 of 2 pre-requisites for Milestone D-E-F", version: "v1")
-          1.times { |i| FactoryBot.create(:workflow_definition_step, process: process8, title: "Step #{i+1}", description: "A single step", position: i*::Workflow::Definition::Step::DEFAULT_INCREMENT) }
+          1.times { |i| FactoryBot.create(:workflow_definition_step, process: process8, title: "Step #{i+1}", description: "A single step") }
           
           process9 = FactoryBot.create(:workflow_definition_process, title: "Milestone D-E-F", description: "Unlocked only when BOTH Milestone D & E are completed", version: "v1")
-          2.times { |i| FactoryBot.create(:workflow_definition_step, process: process9, title: "Collaborative Step #{i+1}", description: "Collaborative Step #{i+1} of 2", completion_type: ::Workflow::Definition::Step::ONE_PER_GROUP, position: i*::Workflow::Definition::Step::DEFAULT_INCREMENT) }
+          2.times { |i| FactoryBot.create(:workflow_definition_step, process: process9, title: "Collaborative Step #{i+1}", description: "Collaborative Step #{i+1} of 2", completion_type: ::Workflow::Definition::Step::ONE_PER_GROUP) }
           
           [process7, process8, process9].each_with_index do |process, i|
             workflow_definition.processes << process

--- a/spec/services/workflow/definition/workflow/remove_process_spec.rb
+++ b/spec/services/workflow/definition/workflow/remove_process_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe Workflow::Definition::Workflow::RemoveProcess do
       end
     end
     
+    context "process is a prerequisite of another process" do
+      let!(:workable_dependency) { Workflow::Definition::Dependency.create(workflow: workflow, prerequisite: process, workable: workable_process) }
+      let(:workable_process) { create(:workflow_definition_process) }
+
+      it "raises an error" do
+        expect { subject.run }.to raise_error(Workflow::Definition::Workflow::RemoveProcessError)
+      end
+    end
+    
     context "selected process associating process is in state: replicated" do
       let!(:selected_process) { create(:selected_process, workflow: workflow, process: process, state: "replicated") }
 

--- a/spec/services/workflow/definition/workflow/remove_process_spec.rb
+++ b/spec/services/workflow/definition/workflow/remove_process_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Workflow::Definition::Workflow::RemoveProcess do
     end
     
     context "process is a prerequisite of another process" do
-      let!(:workable_dependency) { Workflow::Definition::Dependency.create(workflow: workflow, prerequisite: process, workable: workable_process) }
+      let!(:workable_dependency) { Workflow::Definition::Dependency.create(workflow: workflow, prerequisite_workable: process, workable: workable_process) }
       let(:workable_process) { create(:workflow_definition_process) }
 
       it "raises an error" do


### PR DESCRIPTION
- renumbering for processes for instantaneous or rollout changes
- defensive repositioning of steps. Make sure position is an integer greater than 0
- cannot remove a process if it's a prerequisite of another.