### PR TITLE
New versions of process or workflow should not be published

### DIFF
--- a/app/services/workflow/definition/process/new_version.rb
+++ b/app/services/workflow/definition/process/new_version.rb
@@ -8,7 +8,7 @@ module Workflow
           @new_version = nil
           @selected_process = ::Workflow::Definition::SelectedProcess.find_by!(workflow_id: @workflow.id, process_id: @process.id)
         end
-      
+
         def run
           validate
           create_new_version
@@ -17,51 +17,48 @@ module Workflow
           update_selected_process
           return @new_version
         end
-      
+
         private
 
         def validate
-          if @process.version.nil?
-            raise Error.new("process must have a version")
-          end
-         
-          if @workflow.published?
-            raise Error.new("workflow cannot be published")
-          end
+          raise Error, 'process must have a version' if @process.version.nil?
+
+          raise Error, 'workflow cannot be published' if @workflow.published?
         end
 
         def create_new_version
           @new_version = @process.dup
           @new_version.previous_version_id = @process.id
           @new_version.version = "v#{@process.version[1..-1].to_i + 1}"
+          @new_version.published_at = nil 
           @new_version.phase_list = @process.phase_list
           @new_version.category_list = @process.category_list
           @new_version.save!
         end
-      
+
         # TODO: push this to a background worker?
         def clone_steps
           @process.steps.each do |step|
             new_step = step.dup
             new_step.process_id = @new_version.id
             new_step.save!
-          
+
             step.documents.each do |document|
               # documents have external identifier, cannot use dup to clone
               attributes = document.attributes.with_indifferent_access.slice(:documentable_type, :inheritance_type, :title, :link)
               attributes.merge!(documentable_id: new_step.id)
-              new_document = Document.create!(attributes)
+              Document.create!(attributes)
             end
-          
+
             step.decision_options.each do |decision_option|
               # decision options have external identifier, cannot use dup to clone
               attributes = decision_option.attributes.with_indifferent_access.slice(:description)
               attributes.merge!(decision_id: new_step.id)
-              new_decision_option = ::Workflow::DecisionOption.create!(attributes)
+              ::Workflow::DecisionOption.create!(attributes)
             end
           end
         end
-      
+
         # dependencies were already cloned when workflow definition was cloned. Update the process id here.
         def update_dependencies
           @process.workable_dependencies.where(workflow_id: @workflow.id).each do |dependency|
@@ -69,7 +66,7 @@ module Workflow
             dependency.save!
           end
         end
-      
+
         def update_selected_process
           @selected_process.process_id = @new_version.id
           @selected_process.upgrade!

--- a/app/services/workflow/definition/workflow/new_version.rb
+++ b/app/services/workflow/definition/workflow/new_version.rb
@@ -6,14 +6,14 @@ module Workflow
           @workflow = workflow
           @new_version = nil
         end
-      
+
         def run
           create_new_version
           clone_selected_processes
           clone_dependencies
           return @new_version
         end
-      
+
         private
 
         def create_new_version
@@ -23,7 +23,7 @@ module Workflow
           @new_version.published_at = nil
           @new_version.save!
         end
-      
+
         # TODO: pusb this to a background worker?
         def clone_selected_processes
           @workflow.selected_processes.where.not(state: 'removed').each do |sp|
@@ -34,7 +34,7 @@ module Workflow
             new_sp.save!
           end
         end
-      
+
         def clone_dependencies
           @workflow.dependencies.each do |dependency|
             new_dependency = dependency.dup

--- a/spec/services/workflow/definition/process/new_version_spec.rb
+++ b/spec/services/workflow/definition/process/new_version_spec.rb
@@ -1,43 +1,56 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Workflow::Definition::Process::NewVersion, type: :service do
   let(:workflow) { create(:workflow_definition_workflow) }
-  let(:process) { create(:workflow_definition_process, version: "v1") }
+  let(:process) { create(:workflow_definition_process, version: 'v1') }
   let(:new_version_service) { described_class.new(workflow, process) }
   let!(:selected_process) { Workflow::Definition::SelectedProcess.create!(workflow_id: workflow.id, process_id: process.id, state: 'replicated')}
-  let!(:step_with_document) { create(:workflow_definition_step, process: process)}
-  let!(:step_with_decision) { create(:workflow_definition_step_decision, process: process)}
-  let!(:dependency) { Workflow::Definition::Dependency.create!(workflow_id: workflow.id, workable_type: Workflow::Definition::Process, workable_id: process.id, 
-    prerequisite_workable_id: create(:workflow_definition_process).id, prerequisite_workable_type: Workflow::Definition::Process) 
-  }
+  let!(:step_with_document) { create(:workflow_definition_step, process: process) }
+  let!(:step_with_decision) { create(:workflow_definition_step_decision, process: process) }
+  let!(:dependency) do
+    Workflow::Definition::Dependency.create!(
+      workflow_id: workflow.id,
+      workable_type: Workflow::Definition::Process,
+      workable_id: process.id,
+      prerequisite_workable_id: create(:workflow_definition_process).id,
+      prerequisite_workable_type: Workflow::Definition::Process
+    )
+  end
 
-  describe "#run" do
-    it "creates a new process version that points to the old one, all other attributes are the same" do
+  describe '#run' do
+    it 'creates a new process version that points to the old one, all other attributes are the same' do
       new_version = new_version_service.run
       expect(new_version.previous_version).to eq(process)
-      expect(new_version.version).to eq("v2")
+      expect(new_version.version).to eq('v2')
       expect(new_version.title).to eq(process.title)
       expect(new_version.description).to eq(process.description)
     end
-  
-    it "clones the process steps" do
+
+    it 'clones the process steps' do
       new_version = new_version_service.run
       expect(new_version.steps.count).to eq(2)
       new_step_with_decision = new_version.steps.where(kind: Workflow::Definition::Step::DECISION).first
       new_step_with_document = new_version.steps.where(kind: Workflow::Definition::Step::DEFAULT).first
-    
+
       expect(new_step_with_decision.decision_options.first.description).to eq(step_with_decision.decision_options.first.description)
       expect(new_step_with_document.documents.first.link).to eq(step_with_document.documents.first.link)
     end
-  
-    it "updates the dependency to the new process version" do
+
+    it 'updates the dependency to the new process version' do
       new_version = new_version_service.run
       expect(dependency.reload.workable).to eq(new_version)
     end
-  
-    it "updates the selected process to the new process version" do
+
+    it 'updates the selected process to the new process version' do
       new_version = new_version_service.run
       expect(selected_process.reload.process.id).to eq(new_version.id)
+    end
+
+    it 'creates a new process that is not published' do
+      new_version = new_version_service.run
+      expect(new_version.published_at).to be_nil
     end
   end
 end

--- a/spec/services/workflow/definition/workflow/new_version_spec.rb
+++ b/spec/services/workflow/definition/workflow/new_version_spec.rb
@@ -1,37 +1,41 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Workflow::Definition::Workflow::NewVersion, type: :service do
-  let(:workflow) { create(:workflow_definition_workflow, version: "v1") }
+  let(:workflow) { create(:workflow_definition_workflow, version: 'v1') }
   let(:new_version_service) { described_class.new(workflow) }
   let(:prerequisite) { create(:workflow_definition_process) }
   let(:workable_process) { create(:workflow_definition_process) }
 
   before do
     3.times do
-      Workflow::Definition::SelectedProcess.create(workflow_id: workflow.id, process_id: create(:workflow_definition_process).id)
+      workflow_definition_process = create(:workflow_definition_process)
+      Workflow::Definition::SelectedProcess.create(workflow_id: workflow.id, process_id: workflow_definition_process.id)
     end
-  
-    Workflow::Definition::Dependency.create!(workflow: workflow, workable: workable_process, prerequisite_workable:prerequisite)
+
+    Workflow::Definition::Dependency.create!(workflow: workflow, workable: workable_process, prerequisite_workable: prerequisite)
   end
 
-  describe "#run" do
-    it "creates a new version of the workflow" do
-      expect { new_version_service.run }.to change { Workflow::Definition::Workflow.count }.by(1)
+  describe '#run' do
+    it 'creates a new version of the workflow' do
+      expect { new_version_service.run }.to change(Workflow::Definition::Workflow, :count).by(1)
     end
 
-    it "creates new selected processes" do
-      expect { new_version_service.run }.to change { Workflow::Definition::SelectedProcess.count }.by(workflow.selected_processes.count)
+    it 'creates new selected processes' do
+      expect { new_version_service.run }.to change(Workflow::Definition::SelectedProcess, :count).by(workflow.selected_processes.count)
     end
 
-    it "creates new dependencies" do
-      expect { new_version_service.run }.to change { Workflow::Definition::Dependency.count }.by(workflow.dependencies.count)
+    it 'creates new dependencies' do
+      expect { new_version_service.run }.to change(Workflow::Definition::Dependency, :count).by(workflow.dependencies.count)
     end
 
-    it "clones the attributes for the previous version" do
+    it 'clones the attributes for the previous version' do
       new_version = new_version_service.run
       expect(new_version).to be_an_instance_of(Workflow::Definition::Workflow)
       expect(new_version.previous_version_id).to eq(workflow.id)
-      expect(new_version.version).to eq("v2")
+      expect(new_version.version).to eq('v2')
+      expect(new_version.published_at).to be_nil
 
       workflow.selected_processes.each do |sp|
         cloned_selected_process = new_version.selected_processes.find_by(previous_version_id: sp.id)


### PR DESCRIPTION
Some stylistic changes, but mostly the `published_at = nil` is the important change