### PR TITLE
Rollout bugs

### DIFF
--- a/app/controllers/v1/workflow/definition/processes_controller.rb
+++ b/app/controllers/v1/workflow/definition/processes_controller.rb
@@ -32,7 +32,7 @@ class V1::Workflow::Definition::ProcessesController < ApiController
         log_error(e)
         return render json: { message: e.message }, status: :bad_request
       end
-    else 
+    else
       process.update!(process_params)
     end
 

--- a/app/serializers/v1/workflow/process_serializer.rb
+++ b/app/serializers/v1/workflow/process_serializer.rb
@@ -16,7 +16,7 @@ class V1::Workflow::ProcessSerializer < ApplicationSerializer
     process.definition.phase_list.first
   end
 
-    # update this.
+  # update this.
   attribute :steps_assigned_count do |process|
     process.steps.assigned.count
   end
@@ -26,7 +26,7 @@ class V1::Workflow::ProcessSerializer < ApplicationSerializer
   end
 
   has_many :steps, serializer: V1::Workflow::StepSerializer, id_method_name: :external_identifier do |process, params|
-      process.steps.by_position
+    process.steps.by_position
   end
 
   has_many :prerequisite_processes, if: Proc.new { |process, params| params && params[:prerequisites] }, serializer: V1::Workflow::ProcessSerializer, id_method_name: :external_identifier do |process|

--- a/app/services/workflow/definition/process/new_version.rb
+++ b/app/services/workflow/definition/process/new_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Workflow
   module Definition
     class Process
@@ -38,7 +40,7 @@ module Workflow
 
         # TODO: push this to a background worker?
         def clone_steps
-          @process.steps.each do |step|
+          @process.steps.includes([:documents, :decision_options]).each do |step|
             new_step = step.dup
             new_step.process_id = @new_version.id
             new_step.save!
@@ -65,7 +67,7 @@ module Workflow
             dependency.workable = @new_version
             dependency.save!
           end
-          @process.prerequisite_dependencies.where(workflow_id: @workflow.id).each do |prereq_dependency|
+          @process.prerequisite_dependencies.includes([:workflow, :workable]).where(workflow_id: @workflow.id).each do |prereq_dependency|
             prereq_dependency.prerequisite_workable = @new_version
             prereq_dependency.save!
           end

--- a/app/services/workflow/definition/workflow/publish.rb
+++ b/app/services/workflow/definition/workflow/publish.rb
@@ -32,7 +32,8 @@ module Workflow
                 workflow_instance.save!
               end
             rescue Exception => e
-              Rails.logger.error("Error rolling out version changes from workflow definition id #{@workflow.id} to instance id #{workflow_instance.id}: #{e.message}")
+              Rails.logger.error("Rolling out version changes from workflow definition id #{@workflow.id} to instance id #{workflow_instance.id}: ")
+              Rails.logger.error("#{e.message}, for #{e.record.inspect}")
               Rails.logger.error(e.backtrace.join("\n"))
               Highlight::H.instance.record_exception(e)
               @process_stats[:error_raised] = true

--- a/app/services/workflow/definition/workflow/publish.rb
+++ b/app/services/workflow/definition/workflow/publish.rb
@@ -33,7 +33,8 @@ module Workflow
               end
             rescue Exception => e
               Rails.logger.error("Rolling out version changes from workflow definition id #{@workflow.id} to instance id #{workflow_instance.id}: ")
-              Rails.logger.error("#{e.message}, for #{e.record.inspect}")
+              Rails.logger.error("#{e.message},")
+              Rails.logger.error(" for #{e.record.inspect}") if e.respond_to?(:record)
               Rails.logger.error(e.backtrace.join("\n"))
               Highlight::H.instance.record_exception(e)
               @process_stats[:error_raised] = true

--- a/app/services/workflow/definition/workflow/remove_process.rb
+++ b/app/services/workflow/definition/workflow/remove_process.rb
@@ -8,33 +8,31 @@ module Workflow
           @process = process
           @selected_process = ::Workflow::Definition::SelectedProcess.find_by(workflow_id: @workflow.id, process_id: @process.id)
         end
-      
+
         def run
           validate_workflow_state
           validate_dependency_of_others
-          if validate_selected_process_state
-            destroy_association
-          end
+          destroy_association if validate_selected_process_state
         end
-      
+
         private
 
         def validate_workflow_state
           if @workflow.published?
-            raise RemoveProcessError.new('cannot remove processes from a published workflow. Please create a new version to continue.')
+            raise RemoveProcessError, 'cannot remove processes from a published workflow. Please create a new version to continue.'
           end
         end
-      
+
         def validate_dependency_of_others
           unless ::Workflow::Definition::Dependency.where(workflow_id: @workflow.id, prerequisite_workable_id: @process.id, prerequisite_workable_type: @process.class.to_s).empty?
-            raise RemoveProcessError.new('cannot remove process that is a prerequisite of other processes')
+            raise RemoveProcessError, 'cannot remove process that is a prerequisite of other processes'
           end
         end
-      
+
         def validate_selected_process_state
           !@selected_process.removed?
         end
-      
+
         def destroy_association
           if @selected_process.added?
             process = @selected_process.process
@@ -44,18 +42,24 @@ module Workflow
             end
             @selected_process.destroy!
           elsif @selected_process.replicated?
+            # remove dependencies
+            @selected_process.process.workable_dependencies.destroy_all
+            @selected_process.process.prerequisite_dependencies.destroy_all
+
             @selected_process.remove!
           elsif @selected_process.repositioned?
             @selected_process.remove!
           elsif @selected_process.upgraded?
             ::Workflow::Definition::SelectedProcess::Revert.run(@selected_process)
-            @selected_process.remove!
+            @selected_process.reload
+            # once reverted to replicated state, call destroy_association to ensure removal of dependencies
+            destroy_association
           else
-            raise RemoveProcessError.new("selected process is in an invalid state to be removed")
+            raise RemoveProcessError, 'selected process is in an invalid state to be removed'
           end
         end
       end
-    
+
       class RemoveProcessError < StandardError
       end
     end

--- a/app/services/workflow/instance/dependency/create.rb
+++ b/app/services/workflow/instance/dependency/create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Workflow
   module Instance
     class Dependency


### PR DESCRIPTION
1. Bug when reverting a process that was updated by removing its prerequisites. After reverting, prerequisites should reappear
2. Bug when removing a process that has prerequisites. Removing the process should automatically also remove the prerequisite, gracefully.