### PR TITLE
Faster query times

### DIFF
--- a/app/serializers/v1/ssj/team_serializer.rb
+++ b/app/serializers/v1/ssj/team_serializer.rb
@@ -1,5 +1,5 @@
 class V1::SSJ::TeamSerializer < ApplicationSerializer
-  attributes :expected_start_date, :temp_name, :temp_location
+  attributes :expected_start_date, :temp_name
   
   attribute :workflow_id do |team|
     team.workflow&.external_identifier
@@ -13,11 +13,19 @@ class V1::SSJ::TeamSerializer < ApplicationSerializer
     team.partners.count > 1
   end
   
+  attribute :temp_location do |team, params|
+    if params[:team_id]
+      team.temp_location
+    end
+  end
+  
   attribute :invited_partner do |team|
     team.partner_members.invited.count > 0
   end
   
-  has_many :partners, serializer: V1::PersonSerializer ,id_method_name: :external_identifier do |team|
-    team.partners.active
+  has_many :partners, serializer: V1::PersonSerializer ,id_method_name: :external_identifier do |team, params|
+    if params[:team_id]
+      team.partners.active
+    end
   end
 end

--- a/spec/requests/v1/ssj/teams_spec.rb
+++ b/spec/requests/v1/ssj/teams_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe V1::SSJ::TeamsController, type: :request do
         team2 = create(:ssj_team_with_members)
         get "/v1/ssj/teams", headers: headers
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)).to eq(JSON.parse(V1::SSJ::TeamSerializer.new([team2, team1], {include: ['partners']}).to_json))
+        expect(JSON.parse(response.body)).to eq(JSON.parse(V1::SSJ::TeamSerializer.new([team2, team1]).to_json))
       end
     end
 
@@ -99,7 +99,7 @@ RSpec.describe V1::SSJ::TeamsController, type: :request do
       it "returns a successful response with a list of teams" do
         get "/v1/ssj/teams", headers: headers
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)).to eq(JSON.parse(V1::SSJ::TeamSerializer.new([team2, team1], {include: ['partners']}).to_json))
+        expect(JSON.parse(response.body)).to eq(JSON.parse(V1::SSJ::TeamSerializer.new([team2, team1]).to_json))
       end
     end
 


### PR DESCRIPTION
Biggest change is that we're not querying for unneeded information.

Using `params[:team_id]` to indicate if we actually need to calculate `temp_location` or not.