### PR TITLE
Slack messages for background job errors

### DIFF
--- a/app/services/network/update_airtable_records.rb
+++ b/app/services/network/update_airtable_records.rb
@@ -42,7 +42,9 @@ class Network::UpdateAirtableRecords < BaseCommand
     rescue => e
       Rails.logger.error("Error syncing #{name} creates/updates to Airtable; #{updates} updates, #{creates} creates completed. Error: #{e.message}.")
       Highlight::H.instance.record_exception(e)
-      SlackClient.chat_postMessage(channel: '#circle-platform', text: e.message, as_user: true) if Rails.env.production?
+      if Rails.env.production?
+        SlackClient.chat_postMessage(channel: '#circle-platform', text: "Error syncing Airtable: #{e.message}", as_user: true)
+      end
       raise e
     end
   end

--- a/app/services/workflow/definition/workflow/publish.rb
+++ b/app/services/workflow/definition/workflow/publish.rb
@@ -41,7 +41,7 @@ module Workflow
               Rails.logger.error(e.backtrace.join("\n"))
               Highlight::H.instance.record_exception(e)
               if Rails.env.production?
-                SlackClient.chat_postMessage(channel: '#circle-platform', text: e.message, as_user: true)
+                SlackClient.chat_postMessage(channel: '#circle-platform', text: "Error publishing workflow #{@workflow.id}: #{e.message}", as_user: true)
               end
             end
           end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,10 +96,9 @@ Rails.application.configure do
   # Enable cron in production
   config.good_job.enable_cron = true
   config.good_job.on_thread_error = -> (exception) do
-    Rails.error.report(exception)
-    Rails.logger.error("Error executing background job")
+    SlackClient.chat_postMessage(channel: '#circle-platform', text: "Error in background job: #{exception.message}", as_user: true)
     Highlight::H.instance.record_exception(exception)
-    SlackClient.chat_postMessage(channel: '#circle-platform', text: exception.message, as_user: true)
+    Rails.error.report(exception)
   end
 
   # schedule cron job like jobs via good_job gem

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -95,11 +95,6 @@ Rails.application.configure do
   # Enable cron in staging 
   config.good_job.enable_cron = true
   config.good_job.on_thread_error = -> (exception) do 
-    Rails.logger.info("################## TESTING HERE THAT THIS IS BEING RUN")
-    Rails.logger.info("################## Before HIGHLIGHT")
-    Highlight::H.instance.record_exception(exception)
-    SlackClient.chat_postMessage(channel: '#circle-platform', text: exception.message, as_user: true)
-    Rails.logger.info("################## AFTER HIGHLIGHT and SLACK")
     Rails.error.report(exception)
   end
   # schedule cron job like jobs via good_job gem


### PR DESCRIPTION
A bit janky, but Slackbot will ping #circle-platform slack channel when as background job fails.