### PR TITLE
Fix publishing bug

### DIFF
--- a/app/models/workflow/definition/process.rb
+++ b/app/models/workflow/definition/process.rb
@@ -32,7 +32,7 @@ module Workflow
     acts_as_taggable_on :categories, :phase
 
     belongs_to :previous_version, class_name: 'Workflow::Definition::Process', foreign_key: 'previous_version_id', optional: true
-    has_one :next_version, class_name: 'Workflow::Definition::Workflow', foreign_key: 'previous_version_id'
+    has_one :next_version, class_name: 'Workflow::Definition::Process', foreign_key: 'previous_version_id'
 
     before_destroy :validate_destroyable
     before_save :validate_recurring

--- a/app/services/workflow/definition/selected_process/reposition.rb
+++ b/app/services/workflow/definition/selected_process/reposition.rb
@@ -7,7 +7,7 @@ module Workflow
           @workflow = @selected_process.workflow
           @position = position
         end
-      
+
         def run
           validate_position
           validate_if_renumbering_needed
@@ -16,12 +16,14 @@ module Workflow
             update_selected_process_position
             propagate_position_change_to_instances(@selected_process.reload)
           else
-            @selected_process.reposition! unless (@selected_process.upgraded? || @selected_process.added?) # keep the state of an upgraded or added selected process, even after a position change
+            unless @selected_process.upgraded? || @selected_process.added?
+              @selected_process.reposition!
+            end # keep the state of an upgraded or added selected process, even after a position change
             @selected_process.update!(position: @position)
           end
-            
+
           if renumbering_needed?
-            renumber_all_positions
+            renumber_all_positions(@workflow.published?)
             if @workflow.published?
               @workflow.selected_processes.each do |sp|
                 propagate_position_change_to_instances(sp)
@@ -29,22 +31,18 @@ module Workflow
             end
           end
         end
-      
+
         private
 
         def validate_position
-          if @position.to_i.to_s != @position.to_s
-            raise RepositionError.new("new position must be an integer")
-          end
-        
-          if @position.to_i == 0
-            raise RepositionError.new("new position cannot be 0")
-          end
+          raise RepositionError, 'new position must be an integer' if @position.to_i.to_s != @position.to_s
+
+          raise RepositionError, 'new position cannot be 0' if @position.to_i == 0
         end
 
         def validate_if_renumbering_needed
           if renumbering_needed?
-            raise RepositionError.new("cannot reposition selected process because of potential collision")
+            raise RepositionError, 'cannot reposition selected process because of potential collision'
           end
         end
 
@@ -52,31 +50,32 @@ module Workflow
           @selected_process.position = @position
           @selected_process.save!
         end
-      
+
         def propagate_position_change_to_instances(selected_process)
           workflow_instance_ids = @workflow.instances.pluck(:id)
           selected_process.process.instances.where(workflow_id: workflow_instance_ids).update_all(position: selected_process.position)
         end
-      
+
         def renumbering_needed?
           last_position = 0
           @workflow.selected_processes.where.not(position: nil).order(:position).each do |sp|
             delta = sp.position - last_position
-            if delta < 2
-              return true
-            end
+            return true if delta < 2
+
             last_position = sp.position
           end
-          return false
+          false
         end
-      
-        def renumber_all_positions
+
+        def renumber_all_positions(published)
           @workflow.selected_processes.where.not(position: nil).order(:position).each_with_index do |selected_process, i|
             selected_process.position = ::Workflow::Definition::SelectedProcess::DEFAULT_INCREMENT * (i + 1)
             selected_process.save!
+            selected_process.reposition! if !published && selected_process.replicated?
           end
         end
       end
+
       class RepositionError < StandardError
       end
     end

--- a/app/services/workflow/definition/workflow/publish.rb
+++ b/app/services/workflow/definition/workflow/publish.rb
@@ -73,7 +73,7 @@ module Workflow
               add_process_and_dependencies(sp, workflow_instance)
               @process_stats[:added] += 1
             else
-              Rails.logger.info("New process definition #{sp.process_id} cannot be added to this rollout")
+              Rails.logger.info("New process definition #{sp.process_id} cannot be added to this workflow id: #{workflow_instance.id}")
             end
             sp.process.published_at = DateTime.now
             sp.process.save!


### PR DESCRIPTION
When renumbering is needed to avoid collision and the workflow is not published, update sp status to `repositioned` if it's `replicated`. This way, the position will be updated on publish.